### PR TITLE
fix adding user whithin a space

### DIFF
--- a/Modules/core/Controller/CorespaceaccessController.php
+++ b/Modules/core/Controller/CorespaceaccessController.php
@@ -174,8 +174,7 @@ class CorespaceaccessController extends CoresecureController {
                 $_SESSION["message"] = CoreTranslator::AccountHasBeenCreated($lang);
 
                 $user = $modelCoreUser->getInfo($id_user);
-
-                $this->redirect("corespaceaccessuseradd/".$id_space, ['user' => $user, 'pending' => $pid]);
+                $this->redirect("corespaceaccessuseradd/".$id_space, [], ['user' => $user, 'pending' => $pid]);
                 return;
             }
         }


### PR DESCRIPTION
That bug came from one parameter was added to Controller.php redirect() function. It was not taken into account in CorespaceaccessController.php useraddAction().