### PR TITLE
add error messages to booking UI when areas and/or resources are not …

### DIFF
--- a/Modules/booking/Controller/BookingController.php
+++ b/Modules/booking/Controller/BookingController.php
@@ -71,22 +71,16 @@ class BookingController extends BookingabstractController {
         $id_resource = $this->request->getParameterNoException("id_resource");
         $curentDate = $this->request->getParameterNoException("curentDate");
 
-        if ($id_area == "") {
-            if (isset($_SESSION['bk_id_area'])) {
-                $id_area = $_SESSION['bk_id_area'];
-            }
+        if ($id_area == "" && isset($_SESSION['bk_id_area'])) {
+            $id_area = $_SESSION['bk_id_area'];
         }
-        if ($id_resource == "") {
-            if (isset($_SESSION['bk_id_resource'])) {
-                $id_resource = $_SESSION['bk_id_resource'];
-            }
+        if ($id_resource == "" && isset($_SESSION['bk_id_resource'])) {
+            $id_resource = $_SESSION['bk_id_resource'];
         }
-        if ($id_resource == "") {
-            if (isset($_SESSION['bk_curentDate'])) {
-                $curentDate = $_SESSION['bk_curentDate'];
-            }
+        if ($id_resource == "" && isset($_SESSION['bk_curentDate'])) {
+            $curentDate = $_SESSION['bk_curentDate'];
         }
-        //echo "index: id_area = " . $id_area . ", id_resource = " . "curentDate = " . $curentDate . "<br/>";
+
         $this->bookingAction($id_space, $id_area, $id_resource, $curentDate);
     }
 
@@ -108,18 +102,15 @@ class BookingController extends BookingabstractController {
             }
         }
 
-        //echo "curent date booking = " . $curentDate . "<br/>";
         $menuData = $this->calendarMenuData($id_space, $id_area, $id_resource, $curentDate);
 
         $modelResource = new ResourceInfo();
-        $modelArea = New ReArea();
         $userSettingsModel = new CoreUserSettings();
         if ($id_resource == "" || $id_resource == 0) { // booking home page
             $calendarDefaultResource = $userSettingsModel->getUserSetting($_SESSION["id_user"], "calendarDefaultResource");
             if ($calendarDefaultResource != "") {
                 $id_resource = $calendarDefaultResource;
                 $id_area = $modelResource->getAreaID($id_space, $id_resource);
-                $id_site = $modelArea->getSiteID($id_space, $id_area);
             } else {
                 if ($id_area == "" || $id_area == 0) {
                     $modelArea = new ReArea();
@@ -128,18 +119,14 @@ class BookingController extends BookingabstractController {
                     } else {
                         $id_area = $modelArea->getSmallestID($id_space);
                     }
-                    $id_site = $modelArea->getSiteID($id_space, $id_area);
                 }
                 // get the resource with the smallest id
                 $id_resource = $modelResource->firstResourceIDForArea($id_space, $id_area);
             }
-            //echo "id_area = " . $id_area . "</br>";
-            //echo "id_resource = " . $id_resource . "</br>";
-            //$menuData = $this->calendarMenuData($id_area, $id_resource, date("Y-m-d", time()));
+
             $_SESSION['bk_id_resource'] = $id_resource;
             $_SESSION['bk_id_area'] = $id_area;
             $_SESSION['bk_curentDate'] = $curentDate;
-            //echo "booking: id_area = " . $id_area . ", id_resource = " . "curentDate = " . $curentDate . "<br/>";
 
             if ($id_resource == 0) {
                 $this->render(array(
@@ -162,6 +149,7 @@ class BookingController extends BookingabstractController {
         }
     }
 
+    // DEPRECATED? => replaced by bookingAction()? 
     public function book($id_space, $message) {
         $lastView = "";
         if (isset($_SESSION["user_settings"]["calendarDefaultView"])) {
@@ -170,25 +158,25 @@ class BookingController extends BookingabstractController {
         if (isset($_SESSION['lastbookview'])) {
             $lastView = $_SESSION['lastbookview'];
         }
-        if ($lastView == "bookingday") {
-            $this->dayAction($id_space, "", $message);
-            return;
-        } else if ($lastView == "bookingweek") {
-            $this->weekAction($id_space, "", $message);
-            return;
-        } else if ($lastView == "bookingweekarea") {
-            $this->weekareaAction($id_space, "", $message);
-            return;
-        } else if ($lastView == "bookingdayarea") {
-            $this->dayareaAction($id_space, "", $message);
-            return;
+        switch($lastView) {
+            case "bookingday":
+                $this->dayAction($id_space, "", $message);
+                break;
+            case "bookingweek":
+                $this->weekAction($id_space, "", $message);
+                break;
+            case "bookingdayarea":
+                $this->dayareaAction($id_space, "", $message);
+                break;
+            case "bookingweekarea":
+                $this->weekareaAction($id_space, "", $message);
+                break;
+            default:
+                $this->dayAction($id_space, "", $message);
         }
-        $this->dayAction($id_space, "", $message);
     }
 
     public function dayAction($id_space, $action, $message) {
-
-        //print_r($_SESSION);
         $_SESSION['lastbookview'] = "bookingday";
 
         $lang = $this->getLanguage();
@@ -197,8 +185,6 @@ class BookingController extends BookingabstractController {
         $curentResource = $this->request->getParameterNoException('bk_id_resource');
         $curentAreaId = $this->request->getParameterNoException('bk_id_area');
         $curentDate = $this->request->getParameterNoException('bk_curentDate');
-
-        //echo "curent resource bookday 1 = " . $curentResource . "<br/>";
 
         if ($curentDate != "") {
             $curentDate = CoreTranslator::dateToEn($curentDate, $lang);
@@ -210,10 +196,6 @@ class BookingController extends BookingabstractController {
             $curentDate = $_SESSION['bk_curentDate'];
         }
 
-
-        //print_r($_SESSION);
-        //echo "curent resource bookday 2 = " . $curentResource . "<br/>";
-        //sreturn;
         // change input if action
         if ($action == "daybefore") {
             $curentDate = explode("-", $curentDate);
@@ -232,7 +214,6 @@ class BookingController extends BookingabstractController {
         }
 
         $menuData = $this->calendarMenuData($id_space, $curentAreaId, $curentResource, $curentDate);
-        //print_r($menuData);
 
         $foundR = false;
         foreach ($menuData["resources"] as $r) {
@@ -246,28 +227,17 @@ class BookingController extends BookingabstractController {
             $_SESSION['bk_id_resource'] = $curentResource;
         }
 
-
-        // save the menu info in the session
-        //$_SESSION['bk_id_resource'] = $curentResource;
-        //$_SESSION['bk_id_area'] = $curentAreaId;
-        // $_SESSION['bk_id_site'] = $curentSiteId;
         $curentDate = $_SESSION['bk_curentDate'];
 
         // get the resource info
         $modelRescal = new ResourceInfo();
         $resourceInfo = $modelRescal->get($id_space, $curentResource);
 
-        //if (count($resourceInfo) <= 1) {
-        //    $this->redirect("calendar", "booking");
-        //    return;
-        //}
-
         $modelRes = new ResourceInfo();
         $resourceBase = $modelRes->get($id_space, $curentResource);
 
         // get the entries for this resource
         $modelEntries = new BkCalendarEntry();
-        //echo "curent date line 470 = " . $curentDate . "<br/>";
         $dateArray = explode("-", $curentDate);
         $dateBegin = mktime(0, 0, 0, $dateArray[1], $dateArray[2], $dateArray[0]);
         $dateEnd = mktime(23, 59, 59, $dateArray[1], $dateArray[2], $dateArray[0]);
@@ -292,10 +262,14 @@ class BookingController extends BookingabstractController {
         // stylesheet
         $modelCSS = new BkBookingTableCSS();
         $agendaStyle = $modelCSS->getAreaCss($id_space, $curentAreaId);
-        //print_r($agendaStyle);
 
         $modelScheduling = new BkScheduling();
         $scheduling = $modelScheduling->get($id_space, $curentAreaId);
+
+        // Setting an error message if no resource exists
+        if (empty($menuData["resources"])) {
+            $_SESSION["message"] = BookingTranslator::noBookingArea($lang);
+        }
 
         // view
         $this->render(array(
@@ -317,7 +291,6 @@ class BookingController extends BookingabstractController {
 
     public function dayareaAction($id_space, $action, $message) {
         $_SESSION['lastbookview'] = "bookingdayarea";
-
         $lang = $this->getLanguage();
 
         // get inputs
@@ -327,14 +300,15 @@ class BookingController extends BookingabstractController {
 
         if ($curentDate != "") {
             $curentDate = CoreTranslator::dateToEn($curentDate, $lang);
+        } else {
+            $_SESSION['bk_curentDate'] = date("Y-m-d", time());
+            $curentDate = $_SESSION['bk_curentDate'];
         }
 
-        if ($curentAreaId == "") {
-            if (isset($_SESSION['bk_id_resource'])) {
-                $curentResource = $_SESSION['bk_id_resource'];
-                $curentAreaId = $_SESSION['bk_id_area'];
-                $curentDate = $_SESSION['bk_curentDate'];
-            }
+        if ($curentAreaId == "" && isset($_SESSION['bk_id_resource'])) {
+            $curentResource = $_SESSION['bk_id_resource'];
+            $curentAreaId = $_SESSION['bk_id_area'];
+            $curentDate = $_SESSION['bk_curentDate'];
         }
 
         // change input if action
@@ -377,7 +351,6 @@ class BookingController extends BookingabstractController {
         // get the resource info
         $modelRes = new ResourceInfo();
         $modelAccess = new BkAccess();
-        //echo "curentAreaId = " . $curentAreaId . "<br/>"; 
         $resourcesBase = $modelRes->resourcesForArea($id_space, $curentAreaId);
         for ($r = 0; $r < count($resourcesBase); $r++) {
             $resourcesBase[$r]["accessibility_id"] = $modelAccess->getAccessId($id_space, $resourcesBase[$r]["id"]);
@@ -392,7 +365,6 @@ class BookingController extends BookingabstractController {
         // get the entries for this resource
         $modelEntries = new BkCalendarEntry();
         $dateArray = explode("-", $curentDate);
-        //echo "curent date = " . $curentDate . "<br/>";
         $dateBegin = mktime(0, 0, 0, $dateArray[1], $dateArray[2], $dateArray[0]);
         $dateEnd = mktime(23, 59, 59, $dateArray[1], $dateArray[2], $dateArray[0]);
         for ($t = 0; $t < count($resourcesBase); $t++) {
@@ -409,18 +381,20 @@ class BookingController extends BookingabstractController {
 
         // isUserAuthorizedToBook
         foreach ($resourcesBase as $resourceBase) {
-            //print_r($resourceBase);
             $isUserAuthorizedToBook[] = $this->hasAuthorization($resourceBase["id_category"], $resourceBase["accessibility_id"], $id_space, $_SESSION['id_user'], $_SESSION["user_status"], $curentDateUnix);
         }
 
-        //print_r($calEntries);
-        //return;
         // stylesheet
         $modelCSS = new BkBookingTableCSS();
         $agendaStyle = $modelCSS->getAreaCss($id_space, $curentAreaId);
 
         $modelScheduling = new BkScheduling();
         $scheduling = $modelScheduling->get($id_space, $curentAreaId);
+
+        // Setting an error message if no resource exists
+        if (empty($resourcesBase)) {
+            $_SESSION["message"] = BookingTranslator::noBookingArea($lang);
+        }
 
         // view
         $this->render(array(
@@ -477,7 +451,6 @@ class BookingController extends BookingabstractController {
 
         // get the closest monday to curent day
         $i = 0;
-        //echo "curentDate = " . $curentDate . "<br/>";
         $curentDateE = explode("-", $curentDate);
         while (date('D', mktime(0, 0, 0, $curentDateE[1], $curentDateE[2] - $i, $curentDateE[0])) != "Mon") {
             $i++;
@@ -502,18 +475,18 @@ class BookingController extends BookingabstractController {
         //$_SESSION['bk_id_resource'] = $curentResource;
         //$_SESSION['bk_id_area'] = $curentAreaId;
         //$_SESSION['bk_id_area'] = $curentAreaId;
-        //$_SESSION['bk_curentDate'] = $curentDate;
+        $_SESSION['bk_curentDate'] = $curentDate;
         // get the resource info
         $modelRescal = new ResourceInfo();
         $resourceInfo = $modelRescal->get($id_space, $curentResource);
 
+        // Setting an error message if no resource exists
         if (!$resourceInfo) {
-            $this->redirect("booking");
-            return;
+            $_SESSION["message"] = BookingTranslator::noBookingArea($lang);
         }
 
         $modelRes = new ResourceInfo();
-        $resourceBase = $modelRes->get($id_space, $curentResource);
+        $resourcesBase = $modelRes->get($id_space, $curentResource);
 
         // get the entries for this resource
         $modelEntries = new BkCalendarEntry();
@@ -522,7 +495,6 @@ class BookingController extends BookingabstractController {
         $dateEnd = mktime(23, 59, 59, $dateArray[1], $dateArray[2] + 7, $dateArray[0]);
         $calEntries = $modelEntries->getEntriesForPeriodeAndResource($id_space, $dateBegin, $dateEnd, $curentResource);
 
-        //echo "Cal entry count = " . count($calEntries) . "</br>";
         // curentdate unix
         $temp = explode("-", $curentDate);
         $curentDateUnix = mktime(0, 0, 0, $temp[1], $temp[2], $temp[0]);
@@ -533,12 +505,12 @@ class BookingController extends BookingabstractController {
 
         // isUserAuthorizedToBook
         $modelAccess = new BkAccess();
-        $resourceBase["accessibility_id"] = $modelAccess->getAccessId($id_space, $resourceBase["id"]);
-        $isUserAuthorizedToBook = $this->hasAuthorization($resourceBase["id_category"], $resourceBase["accessibility_id"], $id_space, $_SESSION['id_user'], $_SESSION["user_status"], $curentDateUnix);
+        $resourcesBase["accessibility_id"] = $modelAccess->getAccessId($id_space, $resourcesBase["id"]);
+        $isUserAuthorizedToBook = $this->hasAuthorization($resourcesBase["id_category"], $resourcesBase["accessibility_id"], $id_space, $_SESSION['id_user'], $_SESSION["user_status"], $curentDateUnix);
 
         // get last state
         $modelEvent = new ReEvent();
-        $resourceBase["last_state"] = $modelEvent->getLastStateColor($id_space, $resourceBase["id"]);
+        $resourcesBase["last_state"] = $modelEvent->getLastStateColor($id_space, $resourcesBase["id"]);
 
         // stylesheet
         $modelCSS = new BkBookingTableCSS();
@@ -553,7 +525,7 @@ class BookingController extends BookingabstractController {
             'id_space' => $id_space,
             'menuData' => $menuData,
             'resourceInfo' => $resourceInfo,
-            'resourceBase' => $resourceBase,
+            'resourcesBase' => $resourcesBase,
             'date' => $curentDate,
             'date_unix' => $curentDateUnix,
             'mondayDate' => $mondayDate,
@@ -569,7 +541,6 @@ class BookingController extends BookingabstractController {
 
     public function weekareaAction($id_space, $action, $message) {
         $_SESSION['lastbookview'] = "bookingweekarea";
-
         $lang = $this->getLanguage();
 
         // get inputs
@@ -585,8 +556,6 @@ class BookingController extends BookingabstractController {
             $curentResource = $_SESSION['bk_id_resource'];
             $curentAreaId = $_SESSION['bk_id_area'];
             $curentDate = $_SESSION['bk_curentDate'];
-            //echo "curent area id " . $curentAreaId . "<br/>"; 
-            //echo "curent date n-2 = " . $curentDate . "<br/>";
         }
         
         $modelArea = new ReArea();
@@ -596,8 +565,6 @@ class BookingController extends BookingabstractController {
             $curentResource = 0;
         }
         
-
-        //echo "curent date n-1= " . $curentDate . "<br/>";
         // change input if action
         if ($action == "dayweekbefore") {
             $curentDate = explode("-", $curentDate);
@@ -629,13 +596,13 @@ class BookingController extends BookingabstractController {
 
 
         // save the menu info in the session
-        /*
-          $_SESSION['id_resource'] = $curentResource;
-          $_SESSION['id_area'] = $curentAreaId;
-          $_SESSION['curentDate'] = $curentDate;
-         */
+        
+        // $_SESSION['id_resource'] = $curentResource;
+        // $_SESSION['id_area'] = $curentAreaId;
+        $_SESSION['curentDate'] = $curentDate;
+         
         // get the area info
-        $area = $modelArea->get($curentAreaId);
+        $area = $modelArea->get($id_space, $curentAreaId);
 
         // get the resource info
         $modelRes = new ResourceInfo();
@@ -685,6 +652,11 @@ class BookingController extends BookingabstractController {
 
         $modelScheduling = new BkScheduling();
         $scheduling = $modelScheduling->get($id_space, $curentAreaId);
+
+        // Setting an error message if no resource exists
+        if (empty($resourcesBase)) {
+            $_SESSION["message"] = BookingTranslator::noBookingArea($lang);
+        }
 
         // view
         $this->render(array(
@@ -747,7 +719,6 @@ class BookingController extends BookingabstractController {
 
         // get the closest monday to curent day
         $i = 0;
-        //echo "curentDate = " . $curentDate . "<br/>";
         $curentDateE = explode("-", $curentDate);
         while (date('d', mktime(0, 0, 0, $curentDateE[1], $curentDateE[2] - $i, $curentDateE[0])) != 1) {
             $i++;
@@ -771,20 +742,20 @@ class BookingController extends BookingabstractController {
         // save the menu info in the session
         //$_SESSION['id_resource'] = $curentResource;
         //$_SESSION['id_area'] = $curentAreaId;
-        //$_SESSION['curentDate'] = $curentDate;
-        // get the resource info
+        $_SESSION['curentDate'] = $curentDate;
 
+        // get the resource info
         $modelRescal = new ResourceInfo();
         $resourceInfo = $modelRescal->get($id_space, $curentResource);
 
+        // Setting an error message if no resource exists
         if (!$resourceInfo) {
-            $this->redirect("booking");
-            return;
+            $_SESSION["message"] = BookingTranslator::noBookingArea($lang);
         }
 
         // $modelRes = new ResourceInfo();
         // $resourceBase = $modelRes->get($id_space, $curentResource);
-        $resourceBase = $resourceInfo;
+        $resourcesBase = $resourceInfo;
 
         // get the entries for this resource
         $modelEntries = new BkCalendarEntry();
@@ -804,8 +775,8 @@ class BookingController extends BookingabstractController {
 
         // isUserAuthorizedToBook
         $modelAccess = new BkAccess();
-        $resourceBase["accessibility_id"] = $modelAccess->getAccessId($id_space, $resourceBase["id"]);
-        $isUserAuthorizedToBook = $this->hasAuthorization($resourceBase["id_category"], $resourceBase["accessibility_id"], $id_space, $_SESSION['id_user'], $_SESSION["user_status"], $curentDateUnix);
+        $resourcesBase["accessibility_id"] = $modelAccess->getAccessId($id_space, $resourcesBase["id"]);
+        $isUserAuthorizedToBook = $this->hasAuthorization($resourcesBase["id_category"], $resourcesBase["accessibility_id"], $id_space, $_SESSION['id_user'], $_SESSION["user_status"], $curentDateUnix);
 
         $modelCSS = new BkBookingTableCSS();
         $agendaStyle = $modelCSS->getAreaCss($id_space, $curentAreaId);
@@ -816,7 +787,7 @@ class BookingController extends BookingabstractController {
             'id_space' => $id_space,
             'menuData' => $menuData,
             'resourceInfo' => $resourceInfo,
-            'resourceBase' => $resourceBase,
+            'resourcesBase' => $resourcesBase,
             'date' => $curentDate,
             'month' => date("n", $curentTime),
             'year' => date("Y", $curentTime),

--- a/Modules/booking/Model/BookingTranslator.php
+++ b/Modules/booking/Model/BookingTranslator.php
@@ -1594,4 +1594,10 @@ class BookingTranslator {
         return "Booking access";
     }
 
+    public static function noBookingArea($lang) {
+        if ($lang == "fr") {
+            return "Erreur : Aucun domaine et / ou aucune ressource n'a été créé";
+        }
+        return "Error: No resource and/or area has been created";
+    }
 }

--- a/Modules/booking/View/Booking/agendafunction.php
+++ b/Modules/booking/View/Booking/agendafunction.php
@@ -1,6 +1,6 @@
 <?php
 
-function drawAgenda($id_space, $lang, $mois, $annee, $entries, $resourceBase, $agendaStyle) {
+function drawAgenda($id_space, $lang, $mois, $annee, $entries, $resourceBase, $agendaStyle, $resourceInfo) {
 
     $mois_fr = Array("", "Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre");
 
@@ -30,8 +30,13 @@ function drawAgenda($id_space, $lang, $mois, $annee, $entries, $resourceBase, $a
                 </div>
                 <div class="col-md-3">
                     <p ><strong> <?php echo $mois_fr[$mois] . " " . $annee ?></strong></p>
-
+                    <?php
+                        if (!empty($resourceInfo)) {
+                    ?>
                     <p ><strong> <?php echo $resourceBase["name"] ?></strong></p>
+                    <?php
+                        }
+                    ?>
                 </div>
                 <div class="col-md-6" style="text-align: right;">
                     <div class="btn-group" role="group" aria-label="...">

--- a/Modules/booking/View/Booking/bookdayarea.php
+++ b/Modules/booking/View/Booking/bookdayarea.php
@@ -8,8 +8,8 @@ require_once 'Modules/booking/Model/BkBookingSettings.php';
 require_once 'Modules/booking/View/Booking/bookfunction.php';
 ?>
 
-<?php 
-$dayWidth = 100/count($resourcesBase);
+<?php
+$dayWidth = !empty($resourcesBase) ? 100/count($resourcesBase) : 1;
 ?>
 
 <head>

--- a/Modules/booking/View/Booking/bookmonth.php
+++ b/Modules/booking/View/Booking/bookmonth.php
@@ -12,10 +12,41 @@ require_once 'Modules/booking/View/Booking/agendafunction.php';
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<link href="Modules/booking/Theme/styleagenda.css" rel="stylesheet" type="text/css" />
 </head>
-	
+
+<?php
+    if (empty($resourceInfo)) {
+?>
+    <div class="col-lg-12" style="background-color: #ffffff; padding-top: 12px;">
+    <div class="col-lg-10 col-lg-offset-1">
+    <?php
+            $message = "";
+                if (isset($_SESSION["message"])){
+                $message = $_SESSION["message"];
+            } ?>
+        <?php if ($message != ""): 
+            if (strpos($message, "Err") === false){?>
+                <div class="alert alert-success text-center">	
+            <?php 
+            }
+            else{
+            ?>
+                <div class="alert alert-danger text-center">
+            <?php 
+            }
+        ?>
+            <p><?php echo  $message ?></p>
+            </div>
+        <?php endif; unset($_SESSION["message"])?>
+
+    </div>
+    </div>
+<?php
+    }
+?>
+
 <div class="col-xs-12" style="background-color: #ffffff;">
-<?php 	
-drawAgenda($id_space, $lang, $month, $year, $calEntries, $resourceBase, $agendaStyle);
+<?php
+drawAgenda($id_space, $lang, $month, $year, $calEntries, $resourcesBase, $agendaStyle, $resourceInfo);
 ?>
 </div>
 

--- a/Modules/booking/View/Booking/bookweek.php
+++ b/Modules/booking/View/Booking/bookweek.php
@@ -208,73 +208,82 @@ else if($size_bloc_resa == 3600){
 </div>	
 	
 <!-- hours reservation -->
-<div class="col-xs-11" id="colDiv">
+<?php
+	if (!empty($resourceInfo)) {
+?>
 
-	<div id="tcelltop" style="width:100%; height: <?php echo $agendaStyle["header_height"] ?>px; background-color:<?php echo  $agendaStyle["header_background"]?>; color: <?php echo $agendaStyle["header_color"]?>">
-	<p class="text-center"><b><?php echo  $this->clean($resourceBase['name']) ?></b><br/><?php echo  $this->clean($resourceBase['description']) ?>
-        <?php
-            if($resourceBase['last_state'] != ""){
-                ?>
-                    <br/>
-                    <a class="btn btn-xs" href="resourcesevents/<?php echo $id_space ?>/<?php echo $resourceBase['id'] ?>" style="background-color:<?php echo $resourceBase['last_state'] ?> ; color: #fff; width:12px; height: 12px;"></a>
-                <?php
-            }
-            ?>
-        </p>
+	<div class="col-xs-11" id="colDiv">
+
+		<div id="tcelltop" style="width:100%; height: <?php echo $agendaStyle["header_height"] ?>px; background-color:<?php echo  $agendaStyle["header_background"]?>; color: <?php echo $agendaStyle["header_color"]?>">
+		<p class="text-center"><b><?php echo  $this->clean($resourcesBase['name']) ?></b><br/><?php echo  $this->clean($resourcesBase['description']) ?>
+			<?php
+				if($resourcesBase['last_state'] != ""){
+					?>
+						<br/>
+						<a class="btn btn-xs" href="resourcesevents/<?php echo $id_space ?>/<?php echo $resourcesBase['id'] ?>" style="background-color:<?php echo $resourcesBase['last_state'] ?> ; color: #fff; width:12px; height: 12px;"></a>
+					<?php
+				}
+				?>
+			</p>
+		</div>
+
+		
+		<div class="row seven-cols">
+		
+		<?php 
+		for ($d = 0 ; $d < 7 ; $d++){
+			
+			// test if the day is available
+			$isDayAvailable = false;
+			if ($available_days[$d] == 1){
+				$isDayAvailable = true;
+			
+			
+				$idcss = "colDiv";
+				if ($d == 0){
+					$idcss = "colDivleft";
+				}
+				if ($d == 6){
+					$idcss = "colDivright";
+				}
+				
+				// day title
+				$temp = explode("-", $mondayDate);
+				$date_unix = mktime(0,0,0,$temp[1], $temp[2]+$d, $temp[0]);
+				$dayStream = date("l", $date_unix);
+				$monthStream = date("M", $date_unix);
+				$dayNumStream = date("d", $date_unix);
+				$sufixStream = date("S", $date_unix);
+				
+				$dayTitle = BookingTranslator::DateFromTime($date_unix, $lang);
+				//$dayTitle = $dayStream . " " . $monthStream . ". " . $dayNumStream . $sufixStream;
+				
+				?>
+				
+				
+				<div class="col-lg-1 col-md-3 col-sm-4 col-xs-6" id="<?php echo  $idcss ?>">
+				
+				<div id="tcelltop" style="height: 50px; background-color:<?php echo  $agendaStyle["header_background"]?>; color: <?php echo $agendaStyle["header_color"]?>">
+				<p class="text-center"><b> <?php echo  $dayTitle ?></b> </p>
+				</div>
+				
+				<?php 
+				bookday($id_space, $size_bloc_resa, $date_unix, $day_begin, $day_end, $calEntries, $isUserAuthorizedToBook, $isDayAvailable, $agendaStyle);
+				?>
+				
+				</div>
+					<?php
+			} 
+		}
+		?>
+		</div>
+		
 	</div>
 
-	
-	<div class="row seven-cols">
-	
-	<?php 
-	for ($d = 0 ; $d < 7 ; $d++){
-		
-		// test if the day is available
-		$isDayAvailable = false;
-		if ($available_days[$d] == 1){
-			$isDayAvailable = true;
-		
-		
-			$idcss = "colDiv";
-			if ($d == 0){
-				$idcss = "colDivleft";
-			}
-			if ($d == 6){
-				$idcss = "colDivright";
-			}
-			
-			// day title
-			$temp = explode("-", $mondayDate);
-			$date_unix = mktime(0,0,0,$temp[1], $temp[2]+$d, $temp[0]);
-			$dayStream = date("l", $date_unix);
-			$monthStream = date("M", $date_unix);
-			$dayNumStream = date("d", $date_unix);
-			$sufixStream = date("S", $date_unix);
-			
-			$dayTitle = BookingTranslator::DateFromTime($date_unix, $lang);
-			//$dayTitle = $dayStream . " " . $monthStream . ". " . $dayNumStream . $sufixStream;
-			
-			?>
-			
-			
-			<div class="col-lg-1 col-md-3 col-sm-4 col-xs-6" id="<?php echo  $idcss ?>">
-			
-			<div id="tcelltop" style="height: 50px; background-color:<?php echo  $agendaStyle["header_background"]?>; color: <?php echo $agendaStyle["header_color"]?>">
-			<p class="text-center"><b> <?php echo  $dayTitle ?></b> </p>
-			</div>
-			
-			<?php 
-			bookday($id_space, $size_bloc_resa, $date_unix, $day_begin, $day_end, $calEntries, $isUserAuthorizedToBook, $isDayAvailable, $agendaStyle);
-			?>
-			
-			</div>
-				<?php
-		} 
+<?php	
 	}
-	?>
-	</div>
-	
-</div>
+?>
+
 
 <div class="col-xs-12">
 

--- a/Modules/resources/Model/ReArea.php
+++ b/Modules/resources/Model/ReArea.php
@@ -115,7 +115,7 @@ class ReArea extends Model {
      */
     public function getSmallestUnrestrictedID($id_space) {
         $sql = "SELECT id FROM re_area WHERE restricted=0 AND id_space=? AND deleted=0";
-        $req = $this->runRequest($sql);
+        $req = $this->runRequest($sql, array($id_space));
         $tmp = $req->fetch();
         return $tmp? $tmp[0]:0;
     }

--- a/Modules/resources/Model/ResourceInfo.php
+++ b/Modules/resources/Model/ResourceInfo.php
@@ -173,9 +173,9 @@ class ResourceInfo extends Model {
     /**
      * Get the resources info for a given area
      * @param unknown $areaId
-     * @return multitype:
+     * @return array
      */
-    public function resourcesForArea($id_space, $areaId) {
+    public function resourcesForArea($id_space, $areaId): array {
         $sql = "SELECT * from re_info where id_area=? AND id_space=? AND deleted=0 ORDER BY display_order";
         $data = $this->runRequest($sql, array($areaId, $id_space));
         return $data->fetchAll();


### PR DESCRIPTION
It was linked to the calculation of column width in "dayarea" screen in booking module. In fact, width was equal to 100/nb resources. Obviously, If there is no resource in database, it triggers a bug.

We could have forbidden access to booking, but I thought it would be more user friendly to let booking interfaces display (with booking actions unavailable when no resources or areas exist in db).