### PR TITLE
Fix 261 permissions on pendinguserdelete

### DIFF
--- a/Framework/Router.php
+++ b/Framework/Router.php
@@ -345,8 +345,13 @@ class Router {
      *        	Thrown exception
      */
     private function manageError(Throwable $exception, $type = '') {
+        $sendToSentry = true;
 
-        if(Configuration::get('sentry_dsn', '')) {
+        if ($exception instanceof Pfmauthexception) {
+            $sendToSentry = false;
+        }
+
+        if($sendToSentry && Configuration::get('sentry_dsn', '')) {
             \Sentry\captureException($exception);
         }
 

--- a/Framework/Router.php
+++ b/Framework/Router.php
@@ -347,7 +347,7 @@ class Router {
     private function manageError(Throwable $exception, $type = '') {
         $sendToSentry = true;
 
-        if ($exception instanceof Pfmauthexception) {
+        if ($exception instanceof PfmAuthException) {
             $sendToSentry = false;
         }
 

--- a/Modules/core/Controller/CorespaceaccessController.php
+++ b/Modules/core/Controller/CorespaceaccessController.php
@@ -432,7 +432,7 @@ class CorespaceaccessController extends CoresecureController {
      * @param int $id pending account id
      */
     public function pendinguserdeleteAction($id_space, $id) {
-        $this->checkAuthorization(CoreStatus::$ADMIN);
+        $this->checkSpaceAdmin($id_space, $_SESSION["id_user"]);
         $modelPending = new CorePendingAccount();
         $id_user = $modelPending->get($id)["id_user"];
         $modelPending->invalidate($id, $_SESSION["id_user"]);


### PR DESCRIPTION
- from sentry is linked to production environment, not dev, removal of PfmauthExceptions from exceptions send to sentry is not tested
- For purposes of coherence only space admins (and, of course, super admins) are allowed to delete pending users. "Manager" role is not enough. Same authorizations are already applied to affect role to pending users and access users module within a space.