### PR TITLE
Fix resource with no category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * #235 use static data for se_service_types
 * #246 allow user self registration (via config)
 * #244 Allow impersonation
+* #142 fix resource with no category handling
 
 ## 2.0
 

--- a/Modules/resources/Controller/ResourcesinfoController.php
+++ b/Modules/resources/Controller/ResourcesinfoController.php
@@ -61,19 +61,16 @@ class ResourcesinfoController extends CoresecureController {
         );
 
         $modelResource = new ResourceInfo();
-        $resources = $modelResource->getBySpace($id_space);
-
-
-        $logger = Configuration::getLogger();
-        foreach($resources as $resource) {
-            $logger->debug("[TEST][resources]", ["id" => $resource['id'], "name" => $resource["name"]]);
-        }
+        $resources = $modelResource->getBySpaceWithoutCategory($id_space);
 
         $modelArea = new ReArea();
         $modelCategory = new ReCategory();
         for ($i = 0; $i < count($resources); $i++) {
             $resources[$i]["area"] = $modelArea->getName($id_space, $resources[$i]["id_area"]);
             $resources[$i]["category"] = $modelCategory->getName($id_space, $resources[$i]["id_category"]);
+            if ($resources[$i]["category"] === "") {
+                $_SESSION["flash"] = ResourcesTranslator::NoCategoryWarning($resources[$i]['name'], $lang);
+            }
         }
 
         $tableHtml = $table->view($resources, $headers);
@@ -130,7 +127,16 @@ class ResourcesinfoController extends CoresecureController {
         $form->setColumnsWidth(2, 10);
 
         if ($form->check()) {
-            $id = $modelResource->set($form->getParameter("id"), $form->getParameter("name"), $form->getParameter("brand"), $form->getParameter("type"), $form->getParameter("description"), $form->getParameter("long_description"), $form->getParameter("id_category"), $form->getParameter("id_area"), $id_space, $form->getParameter("display_order"));
+            $id = $modelResource->set($form->getParameter("id"),
+            $form->getParameter("name"),
+            $form->getParameter("brand"),
+            $form->getParameter("type"),
+            $form->getParameter("description"),
+            $form->getParameter("long_description"),
+            $form->getParameter("id_category"),
+            $form->getParameter("id_area"),
+            $id_space,
+            $form->getParameter("display_order"));
             
             // upload image
             $target_dir = "data/resources/";

--- a/Modules/resources/Controller/ResourcesinfoController.php
+++ b/Modules/resources/Controller/ResourcesinfoController.php
@@ -64,6 +64,11 @@ class ResourcesinfoController extends CoresecureController {
         $resources = $modelResource->getBySpace($id_space);
 
 
+        $logger = Configuration::getLogger();
+        foreach($resources as $resource) {
+            $logger->debug("[TEST][resources]", ["id" => $resource['id'], "name" => $resource["name"]]);
+        }
+
         $modelArea = new ReArea();
         $modelCategory = new ReCategory();
         for ($i = 0; $i < count($resources); $i++) {

--- a/Modules/resources/Model/ResourceInfo.php
+++ b/Modules/resources/Model/ResourceInfo.php
@@ -99,6 +99,11 @@ class ResourceInfo extends Model {
                 . "WHERE re_info.id_space=? AND re_info.deleted=0";
         return $this->runRequest($sql, array($id_space))->fetchAll();
     }
+
+    public function getBySpaceWithoutCategory($id_space) {
+        $sql = "SELECT * FROM re_info WHERE re_info.id_space=? AND re_info.deleted=0";
+        return $this->runRequest($sql, array($id_space))->fetchAll();
+    }
     
     public function getIdByName($id_space, $name){
         $sql = "SELECT id FROM re_info WHERE name=? AND deleted=0";

--- a/Modules/resources/Model/ResourcesTranslator.php
+++ b/Modules/resources/Model/ResourcesTranslator.php
@@ -380,5 +380,12 @@ class ResourcesTranslator {
         }
         return "Error: As long as this " . $elemType . " is linked to existing resources, you can't delete it";
     }
+
+    public static function NoCategoryWarning($resource_name, $lang = "") {
+        if ($lang == "fr") {
+            return "Votre ressource \"" . $resource_name . "\" n'a pas de catégorie. Vous devriez lui en attribuer une.";
+        }
+        return "Your resource \"" . $resource_name . "\" has no category. You should add one.";
+    }
     
 }


### PR DESCRIPTION
Closes #142 
Because of a different management of resources fetching in database between BookingController and ResourcesinfoController, resources with no category (category has been deleted after resource creation) can be available for booking, but won't display in resources module (so it can't be edited nor deleted).

This fix allows to show resources with non category in resources module. It also warns the user if a category is missing for a resource.