### PR TITLE
Add invoice by quantities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * #272 allow to display news in popup on space home page
 * #275 Fix color codes error in booking schedulings 
 * #292 [ServicesinvoiceorderController] calls to deprecated function createByUnitForm()
+* #298 Add invoice by quantities
 
 ## 2.0.5
 

--- a/Framework/FormAdd.php
+++ b/Framework/FormAdd.php
@@ -148,6 +148,22 @@ class FormAdd {
         $this->choicesid[] = "";
     }
 
+         /**
+     * Add number field with step="any"
+     * @param type $name Field name
+     * @param type $label Field label
+     * @param type $values Field default values
+     */
+    public function addFloat($name, $label, $values = array()) {
+        $this->types[] = "float";
+        $this->names[] = $name;
+        $this->labels[] = $label;
+        $this->setValue($name, $values);
+        $this->isMandatory[] = false;
+        $this->choices[] = "";
+        $this->choicesid[] = "";
+    }
+
     /**
      * 
      * @param type $lang Interface language
@@ -206,6 +222,8 @@ class FormAdd {
                         $html .= $formHtml->inlineDate($this->names[$j], $this->values[$j][$i], true, $lang);
                     } else if ($this->types[$j] == "number") {
                         $html .= $formHtml->inlineNumber($this->names[$j], $this->values[$j][$i], false, true);
+                    } else if ($this->types[$j] == "float") {
+                        $html .= $formHtml->inlineNumber($this->names[$j], $this->values[$j][$i], false, true, true);
                     } else if ($this->types[$j] == "hidden") {
                         $html .= $formHtml->inlineHidden($this->names[$j], $this->values[$j][$i], false, true);
                     } else if ($this->types[$j] == "l"){
@@ -232,6 +250,8 @@ class FormAdd {
                     $html .= $formHtml->inlineDate($this->names[$j], "", true, $lang);
                 } else if ($this->types[$j] == "number") {
                     $html .= $formHtml->inlineNumber($this->names[$j], "", false, true);
+                } else if ($this->types[$j] == "float") {
+                    $html .= $formHtml->inlineNumber($this->names[$j], "", false, true, true);
                 } else if ($this->types[$j] == "hidden") {
                     $html .= $formHtml->inlineHidden($this->names[$j], "", false, true);
                 }

--- a/Framework/FormHtml.php
+++ b/Framework/FormHtml.php
@@ -434,14 +434,15 @@ class FormHtml {
      * @param type $vect
      * @return string
      */
-    static public function inlineNumber($name, $value, $required = false, $vect = false) {
+    static public function inlineNumber($name, $value, $required = false, $vect = false, $isFloat = false) {
 
         $vectv = "";
         if ($vect) {
             $vectv = "[]";
         }
+        $float = $isFloat ? "step=\"any\"" : "";
         $html = "<input class=\"form-control\" type=\"number\" id=\"" . $name . "\" name=\"" . $name . $vectv . "\"";
-        $html .= " value=\"" . $value . "\"" . $required . " ";
+        $html .= " value=\"" . $value . "\"" . $required . " " . $float;
         $html .= "/>";
 
         return $html;

--- a/Framework/formadd_script.php
+++ b/Framework/formadd_script.php
@@ -28,7 +28,7 @@
                     newcell.childNodes[0].value = "";
                     break;
                 case "number":
-                    newcell.childNodes[0].value = "";
+                    newcell.childNodes[0].value = 0;
                     break;  
                 case "hidden":
                     newcell.childNodes[0].value = "";

--- a/Modules/antibodies/Api/AntibodiesApi.php
+++ b/Modules/antibodies/Api/AntibodiesApi.php
@@ -29,7 +29,7 @@ class AntibodiesApi extends CoresecureController {
         $this->checkAuthorizationMenuSpace("antibodies", $id_space, $_SESSION["id_user"]);
         
         $modelTissus = new Tissus();
-        $data = $modelTissus->getTissusById($id_tissus);
+        $data = $modelTissus->getTissusById($id_space, $id_tissus);
         
         echo json_encode($data);
     }
@@ -42,7 +42,7 @@ class AntibodiesApi extends CoresecureController {
         $this->checkAuthorizationMenuSpace("antibodies", $id_space, $_SESSION["id_user"]);
         
         $model = new AcOwner();
-        $data = $model->get($id_owner);
+        $data = $model->get($id_space, $id_owner);
         
         echo json_encode($data);
     }

--- a/Modules/booking/Api/BookingpricesApi.php
+++ b/Modules/booking/Api/BookingpricesApi.php
@@ -29,7 +29,6 @@ class BookingpricesApi extends CoresecureController {
     }
 
     public function getpricesAction($id_space, $id_resource) {
-
         $lang = $this->getLanguage();
         $modelPrices = new BkPrice();
         $modelBelongings = new ClPricing();

--- a/Modules/booking/Api/BookingpricesApi.php
+++ b/Modules/booking/Api/BookingpricesApi.php
@@ -40,26 +40,26 @@ class BookingpricesApi extends CoresecureController {
         $data = array();
 
         $residArray = explode("-", $id_resource);
-        $resourceName = $modelResource->getName($residArray[0]);
+        $resourceName = $modelResource->getName($id_space, $residArray[0]);
         if ($residArray[1] == "day") {
             $data['resource'] = $resourceName;
             foreach($belongings as $bel){
-                $data['bel_' . $bel['id']] = $modelPrices->getDayPrice($residArray[0], $bel["id"]);
+                $data['bel_' . $bel['id']] = $modelPrices->getDayPrice($id_space, $residArray[0], $bel["id"]);
             }
         } else if ($residArray[1] == "night") {
             $data['resource'] = $resourceName . " " . BookingTranslator::night($lang);
             foreach($belongings as $bel){
-                $data['bel_' . $bel['id']] = $modelPrices->getNightPrice($residArray[0], $bel["id"]);
+                $data['bel_' . $bel['id']] = $modelPrices->getNightPrice($id_space, $residArray[0], $bel["id"]);
             }
         } else if ($residArray[1] == "we") {
             $data['resource'] = $resourceName . " " . BookingTranslator::WE($lang);
             foreach($belongings as $bel){
-                $data['bel_' . $bel['id']] = $modelPrices->getWePrice($residArray[0], $bel["id"]);
+                $data['bel_' . $bel['id']] = $modelPrices->getWePrice($id_space, $residArray[0], $bel["id"]);
             }
         } else if ($residArray[1] == "pk") {
-            $data['resource'] = $resourceName . " " . $modelPackage->getName($residArray[2]);
+            $data['resource'] = $resourceName . " " . $modelPackage->getName($id_space, $residArray[2]);
             foreach($belongings as $bel){
-                $data['bel_' . $bel['id']] = $modelPrices->getPackagePrice($residArray[2], $residArray[0], $bel["id"]);
+                $data['bel_' . $bel['id']] = $modelPrices->getPackagePrice($id_space, $residArray[2], $residArray[0], $bel["id"]);
             }
         }
         $data['id_resource'] = $id_resource;

--- a/Modules/booking/Controller/BookingController.php
+++ b/Modules/booking/Controller/BookingController.php
@@ -268,7 +268,8 @@ class BookingController extends BookingabstractController {
 
         // Setting an error message if no resource exists
         if (empty($menuData["resources"])) {
-            $_SESSION["message"] = BookingTranslator::noBookingArea($lang);
+            $_SESSION["flash"] = BookingTranslator::noBookingArea($lang);
+            $_SESSION["flashClass"] = "danger";
         }
 
         // view
@@ -393,7 +394,8 @@ class BookingController extends BookingabstractController {
 
         // Setting an error message if no resource exists
         if (empty($resourcesBase)) {
-            $_SESSION["message"] = BookingTranslator::noBookingArea($lang);
+            $_SESSION["flash"] = BookingTranslator::noBookingArea($lang);
+            $_SESSION["flashClass"] = "danger";
         }
 
         // view
@@ -482,7 +484,8 @@ class BookingController extends BookingabstractController {
 
         // Setting an error message if no resource exists
         if (!$resourceInfo) {
-            $_SESSION["message"] = BookingTranslator::noBookingArea($lang);
+            $_SESSION["flash"] = BookingTranslator::noBookingArea($lang);
+            $_SESSION["flashClass"] = "danger";
         }
 
         $modelRes = new ResourceInfo();
@@ -582,8 +585,6 @@ class BookingController extends BookingabstractController {
             $curentDate = date("Y-m-d", time());
         }
 
-        //echo "curent date n = " . $curentDate . "<br/>";
-        // get the closest monday to curent day
         $i = 0;
         $curentDateE = explode("-", $curentDate);
         while (date('D', mktime(0, 0, 0, $curentDateE[1], $curentDateE[2] - $i, $curentDateE[0])) != "Mon") {
@@ -596,9 +597,6 @@ class BookingController extends BookingabstractController {
 
 
         // save the menu info in the session
-        
-        // $_SESSION['id_resource'] = $curentResource;
-        // $_SESSION['id_area'] = $curentAreaId;
         $_SESSION['curentDate'] = $curentDate;
          
         // get the area info
@@ -655,7 +653,8 @@ class BookingController extends BookingabstractController {
 
         // Setting an error message if no resource exists
         if (empty($resourcesBase)) {
-            $_SESSION["message"] = BookingTranslator::noBookingArea($lang);
+            $_SESSION["flash"] = BookingTranslator::noBookingArea($lang);
+            $_SESSION["flashClass"] = "danger";
         }
 
         // view
@@ -750,11 +749,10 @@ class BookingController extends BookingabstractController {
 
         // Setting an error message if no resource exists
         if (!$resourceInfo) {
-            $_SESSION["message"] = BookingTranslator::noBookingArea($lang);
+            $_SESSION["flash"] = BookingTranslator::noBookingArea($lang);
+            $_SESSION["flashClass"] = "danger";
         }
 
-        // $modelRes = new ResourceInfo();
-        // $resourceBase = $modelRes->get($id_space, $curentResource);
         $resourcesBase = $resourceInfo;
 
         // get the entries for this resource

--- a/Modules/booking/Controller/BookingdefaultController.php
+++ b/Modules/booking/Controller/BookingdefaultController.php
@@ -645,10 +645,7 @@ class BookingdefaultController extends BookingabstractController {
                 $name .= "*";
             }
             $key = array_search($q["id"], $qDataId);
-            $value = "";
-            if ($key !== false) {
-                $value = $qDataValue[$key];
-            }
+            $value = ($key!==false) ? $qDataValue[$key] : 1;
             $form->addNumber("q" . $q["id"], $q["name"], $q["mandatory"], $value);
         }
 
@@ -777,8 +774,8 @@ class BookingdefaultController extends BookingabstractController {
 
     public function deleteAction($id_space, $id) {
         $sendEmail = intval($this->request->getParameter("sendmail"));
+        $modelCalEntry = new BkCalendarEntry();
         if ($sendEmail == 1) {
-            $modelCalEntry = new BkCalendarEntry();
             $entryInfo = $modelCalEntry->getEntry($id_space, $id);
             $id_resource = $entryInfo["resource_id"];
             $resourceModel = new ResourceInfo();

--- a/Modules/booking/Controller/BookinginvoiceController.php
+++ b/Modules/booking/Controller/BookinginvoiceController.php
@@ -11,6 +11,7 @@ require_once 'Modules/invoices/Model/InInvoice.php';
 require_once 'Modules/booking/Model/BkNightWE.php';
 require_once 'Modules/booking/Model/BkPrice.php';
 require_once 'Modules/booking/Model/BkOwnerPrice.php';
+require_once 'Modules/booking/Model/BkCalQuantities.php';
 
 require_once 'Modules/resources/Model/ResourceInfo.php';
 require_once 'Modules/resources/Model/ResourcesTranslator.php';
@@ -110,10 +111,9 @@ class BookinginvoiceController extends InvoiceAbstractController {
             return;
         }
 
-        //print_r($id_items);
         // unparse details
         $detailsData = array();
-        if (count($id_items) > 0) {
+        if (!empty($id_items) > 0) {
             $item = $modelInvoiceItem->getItem($id_space, $id_items[0]["id"]);
             $details = $item["details"];
             
@@ -128,7 +128,7 @@ class BookinginvoiceController extends InvoiceAbstractController {
 
         // create edit form
         $idItem = 0;
-        if (count($id_items) > 0) {
+        if (!empty($id_items) > 0) {
             $idItem = $id_items[0]["id"];
         }
         $form = $this->editForm($idItem, $id_space, $id_invoice, $lang);
@@ -193,17 +193,14 @@ class BookinginvoiceController extends InvoiceAbstractController {
         $itemPrices = array();
         $modelInvoiceItem = new InInvoiceItem();
         $modelInvoice = new InInvoice();
-        //$modelUser = new CoreUser();
         $modelClient = new ClClient();
         
         $invoiceInfo = $modelInvoice->get($id_space ,$id_invoice);
 
         $clientInfo = $modelClient->get($id_space ,$invoiceInfo["id_responsible"]);
-        $id_belonging = $clientInfo["id_pricing"];
+        $id_belonging = $clientInfo["pricing"];
         
         $item = $modelInvoiceItem->getItem($id_space, $id_item);
-        
-        
         $contentArray = explode(";", $item["content"]);
         $total = 0;
         foreach ($contentArray as $content) {
@@ -218,13 +215,10 @@ class BookinginvoiceController extends InvoiceAbstractController {
         }
 
         $listResources = $this->getResourcesList($id_space, $id_belonging, $lang);
-        //echo "id_belonging = " . $id_belonging . "<br/>";
-        //print_r($listResources);
-
         $formAdd = new FormAdd($this->request, "editinvoiceorderformadd");
         $formAdd->addSelect("id_service", ResourcesTranslator::Resource($lang), $listResources["names"], $listResources["ids"], $itemServices);
-        $formAdd->addText("quantity", InvoicesTranslator::Quantity($lang), $itemQuantities);
-        $formAdd->addText("unit_price", InvoicesTranslator::UnitPrice($lang), $itemPrices);
+        $formAdd->addNumber("quantity", InvoicesTranslator::Quantity($lang), $itemQuantities);
+        $formAdd->addFloat("unit_price", InvoicesTranslator::UnitPrice($lang), $itemPrices);
         //$formAdd->addHidden("id_item", $itemIds);
         $formAdd->setButtonsNames(CoreTranslator::Add($lang), CoreTranslator::Delete($lang));
         $form = new Form($this->request, "editinvoiceorderform");
@@ -316,21 +310,39 @@ class BookinginvoiceController extends InvoiceAbstractController {
 
         $modelCal = new BkCalendarEntry();
         $modelInvoice = new InInvoice();
-        
         $modelClient = new ClClient();
         $resps = $modelClient->getAll($id_space);
         
         $number = "";
         foreach ($resps as $resp) {
-            //print_r($resp);
             $billIt = $modelCal->hasResponsibleEntry($id_space, $resp["id"], $beginPeriod, $endPeriod);
-            //echo "billIt = " . $billIt . "<br/>";
             if ($billIt) {
                 $number = $modelInvoice->getNextNumber($number);
                 $this->invoice($id_space, $beginPeriod, $endPeriod, $resp["id"], $number);
             }
         }
     }
+
+    /**
+     * Generate an invoice for the chosen period.
+     * 
+     * To be noticed:
+     * For each reservation, calculate its price (using $this->calculateTimeResDayNightWe()).
+     * 2 general cases:
+     * - resource booked price depends on duration, then it costs Unit price * reservation duration (in hours)
+     * - resource booked price depends on a quantity of elements, then it costs Unit price * nb elements (quantity)
+     * 
+     * Unit prices can depend on the period booked (day, night, week-end)
+     * 
+     * Specific case:
+     * - if a reservation depending on quantity of elements is stradding 2 types of period (i.e. night and day),
+     * then applies a ratio.
+     * example:
+     * for a reservation covering 2 night hours and 6 day hours => nightRatio = 0.25 and dayRatio = 0.75
+     * if nightPrice = 20 / element and dayPrice = 10 / element,
+     * total price = nbElements * (nightPrice * nightRatio) + nbElements * (dayPrice * dayRatio)
+     * 
+     */
 
     protected function invoice($id_space, $beginPeriod, $endPeriod, $id_resp, $number = "") {
 
@@ -345,17 +357,13 @@ class BookinginvoiceController extends InvoiceAbstractController {
         $modelResouces = new ResourceInfo();
         $resources = $modelResouces->getBySpace($id_space);
 
-        //echo "LABpricingid = " . $LABpricingid . "<br/>";
         // get the pricing
-        $timePrices = $this->getUnitTimePricesForEachResource($id_space, $resources, $LABpricingid, $id_resp, $id_space);
-        //echo "pass 1<br/>";
+        $timePrices = $this->getUnitTimePricesForEachResource($id_space, $resources, $LABpricingid, $id_resp);
         $packagesPrices = $this->getUnitPackagePricesForEachResource($id_space, $resources, $LABpricingid, $id_resp);
-        //echo "pass 2<br/>";
+        
         // add the invoice to the database
         $modelInvoice = new InInvoice();
-        if ($number == "") {
-            $number = $modelInvoice->getNextNumber();
-        }
+        $number = ($number === "") ? $modelInvoice->getNextNumber() : $number;
         $module = "booking";
         $controller = "Bookinginvoice";
         $date_generated = date("Y-m-d", time());
@@ -367,8 +375,24 @@ class BookinginvoiceController extends InvoiceAbstractController {
         $content = "";
         $total_ht = 0;
         $modelCal = new BkCalendarEntry();
+        $bkCalQuantitiesModel = new BkCalQuantities();
         foreach ($resources as $res) {
+            // get reservations
             $reservations = $modelCal->getUnpricedReservations($id_space, $beginPeriod, $endPeriod, $res["id"], $id_resp);
+
+            // get list of quantities
+            $calQuantities = $bkCalQuantitiesModel->calQuantitiesByResource($id_space, $res["id"]);
+            $calQuantities = ($calQuantities != null) ? $calQuantities : [];
+
+            // tell if there's an invoicing unit for this resource amongst quantities and get its ID
+            $isInvoicingUnit = false;
+            $calQuantityId = "";
+            foreach ($calQuantities as $calQuantity) {
+                if ($calQuantity["is_invoicing_unit"] && intval($calQuantity["is_invoicing_unit"]) === 1) {
+                    $calQuantityId = $calQuantity["id"];
+                    $isInvoicingUnit = true;
+                }
+            }
 
             // get all packages
             $userPackages = array();
@@ -377,28 +401,51 @@ class BookinginvoiceController extends InvoiceAbstractController {
             }
 
             $userTime = array();
-            //print_r($reservations);
             $userTime["nb_hours_day"] = 0;
             $userTime["nb_hours_night"] = 0;
             $userTime["nb_hours_we"] = 0;
-            foreach ($reservations as $reservation) {
+            $userTime["ratio_bookings_day"] = 0;
+            $userTime["ratio_bookings_night"] = 0;
+            $userTime["ratio_bookings_we"] = 0;      
+            $totalQte = 0; // $totalQte = total number of items booked
 
+            foreach ($reservations as $reservation) {
                 // count: day night we, packages
                 if ($reservation["package_id"] > 0) {
                     $userPackages[$reservation["package_id"]] ++;
                 } else {
-                    $resaDayNightWe = $this->calculateTimeResDayNightWe($id_space ,$reservation, $timePrices[$res["id"]]);
-                    $userTime["nb_hours_day"] += $resaDayNightWe["nb_hours_day"];
-                    $userTime["nb_hours_night"] += $resaDayNightWe["nb_hours_night"];
-                    $userTime["nb_hours_we"] += $resaDayNightWe["nb_hours_we"];
+                    $resaDayNightWe = $this->calculateTimeResDayNightWe($reservation, $timePrices[$res["id"]]);
+                    if ($isInvoicingUnit) {
+                        if ($reservation["quantities"] && $reservation["quantities"] != null) {
+                            // varchar formatted like "$mandatory=$quantity;" in bk_calendar_entry
+                            // get number of resources booked
+                            $strToFind = strval($calQuantityId) . "=";
+                            $lastPos = 0;
+                            $positions = array();
+                            while(($lastPos = strpos($reservation["quantities"], $strToFind, $lastPos))!==false) {
+                                $positions[] = $lastPos;
+                                $lastPos = $lastPos + strlen($strToFind);
+                            }
+                            $foundStr = substr($reservation["quantities"], $positions[0]);
+                            $qte = intval(explode("=", $foundStr)[1]);
+                        } else {
+                            $qte = 0;
+                        }
+                        $totalQte += $qte;
+                        $userTime["ratio_bookings_day"] += $resaDayNightWe["ratio_bookings_day"];
+                        $userTime["ratio_bookings_night"] += $resaDayNightWe["ratio_bookings_night"];
+                        $userTime["ratio_bookings_we"] += $resaDayNightWe["ratio_bookings_we"];
+                    } else {
+                        $userTime["nb_hours_day"] += $resaDayNightWe["nb_hours_day"];
+                        $userTime["nb_hours_night"] += $resaDayNightWe["nb_hours_night"];
+                        $userTime["nb_hours_we"] += $resaDayNightWe["nb_hours_we"];
+                    }
                 }
-                
+                // Record that an invoice was generated for this reservation (so that we can't re-invoice if existing)
                 $modelCal->setReservationInvoice($id_space, $reservation["id"], $invoice_id);
             }
             // fill content
             if (count($reservations) > 0) {
-                //echo "<br/> user time day = " . $userTime["nb_hours_day"] . "<br/>";
-
                 if ($userTime["nb_hours_day"] > 0) {
                     $content .= $res["id"] . "_day=" . $userTime["nb_hours_day"] . "=" . $timePrices[$res["id"]]["price_day"] . ";";
                     $total_ht += floatval($userTime["nb_hours_day"]) * floatval($timePrices[$res["id"]]["price_day"]);
@@ -417,8 +464,25 @@ class BookinginvoiceController extends InvoiceAbstractController {
                         $total_ht += floatval($userPackages[$p["id"]]) * floatval($p["price"]);
                     }
                 }
+                // manage quantity
+                if ($totalQte > 0) {
+                    if ($userTime["ratio_bookings_day"] > 0) {
+                        $dayQte = $totalQte * $userTime["ratio_bookings_day"];
+                        $content .= $res["id"] . "_day=" . $dayQte . "=" . $timePrices[$res["id"]]["price_day"] . ";";
+                        $total_ht += floatval($dayQte) * floatval($timePrices[$res["id"]]["price_day"]);
+                    }
+                    if ($userTime["ratio_bookings_night"] > 0) {
+                        $nightQte = $totalQte * $userTime["ratio_bookings_night"];
+                        $content .= $res["id"] . "_night=" . $nightQte . "=" . $timePrices[$res["id"]]["price_night"] . ";";
+                        $total_ht += floatval($nightQte) * floatval($timePrices[$res["id"]]["price_night"]);
+                    }
+                    if ($userTime["ratio_bookings_we"] > 0) {
+                        $weQte = $totalQte * $userTime["ratio_bookings_we"];
+                        $content .= $res["id"] . "_we=" . $weQte . "=" . $timePrices[$res["id"]]["price_we"] . ";";
+                        $total_ht += floatval($weQte) * floatval($timePrices[$res["id"]]["price_we"]);
+                    }
+                }
             }
-            //echo "<br/> content: $content <br/>";
         }
 
         // details
@@ -437,7 +501,7 @@ class BookinginvoiceController extends InvoiceAbstractController {
         ]);
     }
 
-    protected function getUnitPackagePricesForEachResource($resources, $LABpricingid, $id_client) {
+    protected function getUnitPackagePricesForEachResource($id_space, $resources, $LABpricingid, $id_client) {
 
         // calculate the reservations for each equipments
         $packagesPrices = array();
@@ -460,31 +524,55 @@ class BookinginvoiceController extends InvoiceAbstractController {
             }
             $packagesPrices[$resource["id"]] = $pricesPackages;
         }
-
-        //print_r($packagesPrices);
         return $packagesPrices;
     }
 
-    protected function getUnitTimePricesForEachResource($resources, $LABpricingid, $id_cient, $id_space) {
+    protected function getUnitTimePricesForEachResource($id_space, $resources, $LABpricingid, $id_cient) {
 
         
         
         // get the pricing informations
         $pricingModel = new BkNightWE();
         $pricingInfo = $pricingModel->getPricing($LABpricingid, $id_space);
-        //echo "getUnitTimePricesForEachResource 1 <br>";
-        //$tarif_name = $pricingInfo['tarif_name'];
-        $tarif_unique = $pricingInfo['tarif_unique'];
-        $tarif_nuit = $pricingInfo['tarif_night'];
-        $tarif_we = $pricingInfo['tarif_we'];
-        $night_start = $pricingInfo['night_start'];
-        $night_end = $pricingInfo['night_end'];
-        $we_array1 = explode(",", $pricingInfo['choice_we']);
-        $we_array = array();
-        for ($s = 0; $s < count($we_array1); $s++) {
-            if ($we_array1[$s] > 0) {
-                $we_array[] = $s + 1;
+        if (!empty($pricingInfo)) {
+            $tarif_unique = $pricingInfo['tarif_unique'];
+            $tarif_nuit = $pricingInfo['tarif_night'];
+            $tarif_we = $pricingInfo['tarif_we'];
+            $night_start = $pricingInfo['night_start'];
+            $night_end = $pricingInfo['night_end'];
+            $we_array1 = explode(",", $pricingInfo['choice_we']);
+            $we_array = array();
+            for ($s = 0; $s < count($we_array1); $s++) {
+                if ($we_array1[$s] > 0) {
+                    $we_array[] = $s + 1;
+                }
             }
+        } else {
+            // Set default values for invoice generation
+            $tarif_unique = 1;
+            $tarif_nuit = 0;
+            $tarif_we = 0;
+            $night_start = 19;
+            $night_end = 8;
+            $we_array = array(0, 0, 0, 0, 0, 1, 1);
+
+            // Insert default values in bk_nightwe table
+            $bkNightWeModel = new BkNightWE();
+            $we_char = "";
+            foreach ($we_array as $day) {
+                $we_char .= $day . ",";
+            }
+            $we_char = substr($we_char, 0, -1);
+            $bkNightWeModel->addPricing(
+                $LABpricingid,
+                $id_space,
+                $tarif_unique,
+                $tarif_nuit,
+                $night_start,
+                $night_end,
+                $tarif_we,
+                $we_char
+            );
         }
 
         $timePrices = array();
@@ -524,11 +612,14 @@ class BookinginvoiceController extends InvoiceAbstractController {
         return $timePrices;
     }
 
+    /**
+     * Refer to $this->invoice() for details
+     * 
+     */
     protected function calculateTimeResDayNightWe($reservation, $timePrices) {
 
         // initialize output
         $nb_hours_day = 0;
-
         $nb_hours_night = 0;
         $nb_hours_we = 0;
 
@@ -541,7 +632,7 @@ class BookinginvoiceController extends InvoiceAbstractController {
         $searchDate_end = $reservation["end_time"];
 
         // calulate pricing
-        if ($timePrices["tarif_unique"] > 0) { // unique pricing
+        if (intval($timePrices["tarif_unique"]) === 1) { // unique pricing
             $nb_hours_day = ($searchDate_end - $searchDate_start);
         } else {
             $gap = 60;
@@ -567,8 +658,11 @@ class BookinginvoiceController extends InvoiceAbstractController {
         $resaDayNightWe["nb_hours_night"] = round($nb_hours_night / 3600, 1);
         $resaDayNightWe["nb_hours_we"] = round($nb_hours_we / 3600, 1);
 
-        //print_r($resaDayNightWe);
-        //echo "<br/>";
+        // manage cases where a booking is between day and night hours => get a ratio
+        $totalHours = $nb_hours_day + $nb_hours_night + $nb_hours_we;
+        $resaDayNightWe["ratio_bookings_day"] = round($nb_hours_day / $totalHours, 2);
+        $resaDayNightWe["ratio_bookings_night"] = round($nb_hours_night / $totalHours, 2);
+        $resaDayNightWe["ratio_bookings_we"] = round($nb_hours_we / $totalHours, 2);
         return $resaDayNightWe;
     }
 
@@ -685,8 +779,8 @@ class BookinginvoiceController extends InvoiceAbstractController {
         $tabledata = $this->invoiceTable($id_space, $invoice, $id_item, $lang);
         $table = $tabledata["table"];
         $total = $tabledata["total"];
-        $details = $this->detailsTable($id_space, invoice["id"], $lang);
-
+        $details = $this->detailsTable($id_space, $invoice["id"], $lang);
+        
         $modelClient = new ClClient();
         $unit = "";
         $adress = $modelClient->getAddressInvoice($id_space, $invoice["id_responsible"]);

--- a/Modules/booking/Controller/BookingpricesController.php
+++ b/Modules/booking/Controller/BookingpricesController.php
@@ -191,7 +191,7 @@ class BookingpricesController extends CoresecureController {
         $units = $unitModel->getUnitsForList("name");
         
         $modelOwnerPrices = new BkOwnerPrice();
-        $data = $modelOwnerPrices->getAll();
+        $data = $modelOwnerPrices->getAll($id_space);
         $dataResources = array();
         $dataUnits = array();
         $dataPrice = array();
@@ -226,18 +226,18 @@ class BookingpricesController extends CoresecureController {
             $units = $this->request->getParameter("unit");
             $prices = $this->request->getParameter("price");
             
-            $modelPrice->removeNotListed($id_resource, $units);
+            $modelPrice->removeNotListed($id_space, $id_resource, $units);
             
             for ($i = 0; $i < count($id_resource); $i++) {
                 $residArray = explode("_", $id_resource[$i]);
                 if ($residArray[1] == "day") {
-                    $modelPrice->setPriceDay($id_resource[$i], $units[$i], $prices[$i]);
+                    $modelPrice->setPriceDay($id_space, $id_resource[$i], $units[$i], $prices[$i]);
                 } else if ($residArray[1] == "night") {
-                    $modelPrice->setPriceNight($id_resource[$i], $units[$i], $prices[$i]);
+                    $modelPrice->setPriceNight($id_space, $id_resource[$i], $units[$i], $prices[$i]);
                 } else if ($residArray[1] == "we") {
-                    $modelPrice->setPriceWe($id_resource[$i], $units[$i], $prices[$i]);
+                    $modelPrice->setPriceWe($id_space, $id_resource[$i], $units[$i], $prices[$i]);
                 } else if ($residArray[1] == "pk") {
-                    $modelPrice->setPricePackage($id_resource[$i], $units[$i], $residArray[2], $prices[$i]);
+                    $modelPrice->setPricePackage($id_space, $id_resource[$i], $units[$i], $residArray[2], $prices[$i]);
                 }
             }
             
@@ -266,13 +266,13 @@ class BookingpricesController extends CoresecureController {
             $resourcesIds[$count] = $resources[$i]["id"] . "_day";
             $resourcesNames[$count] = $resources[$i]["name"];
             // add night we
-            $isNight = $modelPNightWe->isNight($belongings[0]["id"]);
+            $isNight = $modelPNightWe->isNight($id_space, $belongings[0]["id"]);
             if ($isNight) {
                 $count++;
                 $resourcesIds[$count] = $resources[$i]["id"] . "_night";
                 $resourcesNames[$count] = $resources[$i]["name"] . " " . BookingTranslator::night($lang);
             }
-            $isWe = $modelPNightWe->isWe($belongings[0]["id"]);
+            $isWe = $modelPNightWe->isWe($id_space, $belongings[0]["id"]);
             if ($isWe) {
                 $count++;
                 $resourcesIds[$count] = $resources[$i]["id"] . "_we";
@@ -280,7 +280,7 @@ class BookingpricesController extends CoresecureController {
             }
 
             // add forfaits
-            $packages = $modelPackage->getByResource($resources[$i]["id"]);
+            $packages = $modelPackage->getByResource($id_space, $resources[$i]["id"]);
             foreach ($packages as $package) {
                 $count++;
                 $resourcesIds[$count] = $resources[$i]["id"] . "_pk_" . $package["id"];

--- a/Modules/booking/Controller/BookingpricesController.php
+++ b/Modules/booking/Controller/BookingpricesController.php
@@ -45,8 +45,8 @@ class BookingpricesController extends CoresecureController {
         $modelResource = new ResourceInfo();
         $resources = $modelResource->getBySpace($id_space);
         
+        // TODO: handle case where $belongings = null; Causes warnings in dev mode
         $belongings = $modelPricing->getAll($id_space);
-        
         $table = new TableView();
         
         $modelConfig = new CoreConfig();

--- a/Modules/booking/Controller/BookingquantitiesController.php
+++ b/Modules/booking/Controller/BookingquantitiesController.php
@@ -29,7 +29,6 @@ class BookingquantitiesController extends CoresecureController {
      * @see Controller::indexAction()
      */
     public function indexAction($id_space) {
-
         $this->checkAuthorizationMenuSpace("bookingsettings", $id_space, $_SESSION["id_user"]);
         
         $lang = $this->getLanguage();
@@ -48,12 +47,12 @@ class BookingquantitiesController extends CoresecureController {
         $supsIdsRes = array();
         $supsNames = array();
         $supsMandatories = array();
-        foreach($sups as $p){
-            $supsIds[] = $p["id_quantity"];
-            $supsIdsRes[] = $p["id_resource"];
-            $supsNames[] = $p["name"];
-            $supsMandatories[] = $p["mandatory"];
-            $supIsInvoicingUnit[] = $p["is_invoicing_unit"] ? intval($p["is_invoicing_unit"]) : 0;
+        foreach($sups as $sup){
+            $supsIds[] = $sup["id_quantity"];
+            $supsIdsRes[] = $sup["id_resource"];
+            $supsNames[] = $sup["name"];
+            $supsMandatories[] = $sup["mandatory"];
+            $supIsInvoicingUnit[] = $sup["is_invoicing_unit"] ? intval($sup["is_invoicing_unit"]) : 0;
         }
         
         $form = new Form($this->request, "supsForm");
@@ -63,8 +62,8 @@ class BookingquantitiesController extends CoresecureController {
         $formAdd->addHidden("id_sups", $supsIds);
         $formAdd->addSelect("id_resources", BookingTranslator::Resource($lang) , $choicesR, $choicesRid, $supsIdsRes);
         $formAdd->addText("names", CoreTranslator::Name($lang), $supsNames);
-        $formAdd->addSelect("mandatory", BookingTranslator::Is_mandatory($lang) , array(CoreTranslator::yes($lang), CoreTranslator::no($lang)), array(1,0), $supsMandatories);
-        $formAdd->addSelect("is_invoicing_unit", BookingTranslator::Is_invoicing_unit($lang) , array(CoreTranslator::yes($lang), CoreTranslator::no($lang)), array(1,0), $supIsInvoicingUnit);
+        $formAdd->addSelect("mandatory", BookingTranslator::Is_mandatory($lang) , array(CoreTranslator::no($lang), CoreTranslator::yes($lang)), array(0,1), $supsMandatories);
+        $formAdd->addSelect("is_invoicing_unit", BookingTranslator::Is_invoicing_unit($lang) , array(CoreTranslator::no($lang), CoreTranslator::yes($lang)), array(0,1), $supIsInvoicingUnit);
         
         $formAdd->setButtonsNames(CoreTranslator::Add(), CoreTranslator::Delete($lang));
         $form->setFormAdd($formAdd);  
@@ -73,7 +72,7 @@ class BookingquantitiesController extends CoresecureController {
         
         if ($form->check()){
             $supID = $this->request->getParameterNoException("id_sups");
-            $supResource = $this->request->getParameterNoException("id_resources");
+            $supResources = $this->request->getParameterNoException("id_resources");
             $supName = $this->request->getParameterNoException("names");
             $supMandatory = $this->request->getParameterNoException("mandatory");
             $supIsInvoicingUnit = $this->request->getParameterNoException("is_invoicing_unit");
@@ -81,79 +80,55 @@ class BookingquantitiesController extends CoresecureController {
             // format into arrays
             $supIsInvoicingUnit = is_array($supIsInvoicingUnit) ? $supIsInvoicingUnit : [$supIsInvoicingUnit];
             $supID = is_array($supID) ? $supID : [$supID];
+            $supResources = is_array($supResources) ? $supResources : [$supResources];
 
-            // TODO: check if this next loops are ok
-            $packs = [];
-            for ($p = 0; $p < count($supID); $p++) {
-                if ($supName[$p] != "" && $supID[$p]) {
-                   $packs[$supName[$p]] = $supID[$p];
+            // find out if multiple quantities are used as invoicing units
+            $invoicingUnitsResources = [];
+            foreach ($supResources as $index => $resource) {
+                if ($supIsInvoicingUnit[$index] == 1) {
+                    if (in_array($resource, $invoicingUnitsResources)) {
+                        $_SESSION["flash"] = BookingTranslator::maxInvoicingUnits($lang);
+                        $_SESSION["flashClass"] = "danger";
+                        $this->redirect("bookingquantities/".$id_space);
+                    } else {
+                        array_push($invoicingUnitsResources, $resource);
+                    }
                 }
             }
-            for ($p = 0; $p < count($supID); $p++) {
-                if (!$supID[$p]) {
+
+            $supacks = [];
+            for ($sup = 0; $sup < count($supID); $sup++) {
+                if ($supName[$sup] != "" && $supID[$sup]) {
+                   $supacks[$supName[$sup]] = $supID[$sup];
+                }
+            }
+            for ($sup = 0; $sup < count($supID); $sup++) {
+                if (!$supID[$sup]) {
                     // If package id not set, use from known packages
-                    if(isset($packs[$supName[$p]])) {
-                        $supID[$p] = $packs[$supName[$p]];
+                    if(isset($supacks[$supName[$sup]])) {
+                        $supID[$sup] = $supacks[$supName[$sup]];
                     } else {
                         // Or create a new package
                        $cvm = new CoreVirtual();
                        $vid = $cvm->new('quantities');
-                       $supID[$p] = $vid;
-                       $packs[$supName[$p]] = $vid;
+                       $supID[$sup] = $vid;
+                       $supacks[$supName[$sup]] = $vid;
                    }
                 }
-                $modelSups->setCalQuantity($id_space,  $supID[$p], $supResource[$p], $supName[$p], $supMandatory[$p]);
+                $modelSups->setCalQuantity($id_space,  $supID[$sup], $supResources[$sup], $supName[$sup], $supMandatory[$sup], $supIsInvoicingUnit[$sup]);
             }
-            
-
-            /* bug to get last id (could conflict)
-            // get the last package id
-            $lastID = 0;
-            for( $p = 0 ; $p < count($supID) ; $p++){
-                if ($supName[$p] != "" ){
-                    if ($supID[$p] > $lastID){
-                        $lastID = $supID[$p];
-                    }
-                }
-            }
-                
-            for( $p = 0 ; $p < count($supID) ; $p++){
-                if ($supName[$p] != "" ){
-                    $curentID = $supID[$p];
-
-                    if ($curentID == ""){
-                        $lastID++;
-                        $curentID = $lastID;
-                        $supID[$p] = $lastID;
-                    }
-                    if ($curentID == 1 && $p > 0){
-                        $lastID++;
-                        $curentID = $lastID;
-                        $supID[$p] = $lastID;
-                    }
-                    if(! in_array($supResource[$p], $choicesRid)) {
-                        continue;
-                    }
-                    //echo "set package (".$curentID." , " . $id_resource ." , " . $packageName[$p]." , ". $packageDuration[$p] . ")<br/>";
-                    $modelSups->setCalQuantity($id_space, $curentID, $supResource[$p], $supName[$p], $supMandatory[$p]);
-                    $count++;
-                }
-            }
-            */
-            
-            //echo "sups ids = ". print_r($supID) . "<br/>";
-            //echo "sup Resource ids = ". print_r($supResource) . "<br/>";
             
             $sups = $modelSups->getForSpace($id_space, "id_resource");
             // If package in db is not listed in provided package list, delete them
-            foreach ($sups as $s) {
-                if($s['id_quantity'] && !in_array($s['id_quantity'], $supID)) {
-                    $modelSups->delete($id_space, $s['id']);
+            foreach ($sups as $sup) {
+                if($sup['id_quantity'] && !in_array($sup['id_quantity'], $supID)) {
+                    $modelSups->delete($id_space, $sup['id']);
                 }
             } 
 
-            // $modelSups->removeUnlistedQuantities($supID);
-            $_SESSION["message"] = BookingTranslator::Quantities_saved($lang);
+            $modelSups->removeUnlistedQuantities($id_space, $supID);
+            $_SESSION["flash"] = BookingTranslator::Quantities_saved($lang);
+            $_SESSION["flashClass"] = "success";
             $this->redirect("bookingquantities/".$id_space);
             return;
         }

--- a/Modules/booking/Controller/BookingquantitiesController.php
+++ b/Modules/booking/Controller/BookingquantitiesController.php
@@ -53,6 +53,7 @@ class BookingquantitiesController extends CoresecureController {
             $supsIdsRes[] = $p["id_resource"];
             $supsNames[] = $p["name"];
             $supsMandatories[] = $p["mandatory"];
+            $supIsInvoicingUnit[] = $p["is_invoicing_unit"] ? intval($p["is_invoicing_unit"]) : 0;
         }
         
         $form = new Form($this->request, "supsForm");
@@ -63,6 +64,7 @@ class BookingquantitiesController extends CoresecureController {
         $formAdd->addSelect("id_resources", BookingTranslator::Resource($lang) , $choicesR, $choicesRid, $supsIdsRes);
         $formAdd->addText("names", CoreTranslator::Name($lang), $supsNames);
         $formAdd->addSelect("mandatory", BookingTranslator::Is_mandatory($lang) , array(CoreTranslator::yes($lang), CoreTranslator::no($lang)), array(1,0), $supsMandatories);
+        $formAdd->addSelect("is_invoicing_unit", BookingTranslator::Is_invoicing_unit($lang) , array(CoreTranslator::yes($lang), CoreTranslator::no($lang)), array(1,0), $supIsInvoicingUnit);
         
         $formAdd->setButtonsNames(CoreTranslator::Add(), CoreTranslator::Delete($lang));
         $form->setFormAdd($formAdd);  
@@ -74,10 +76,13 @@ class BookingquantitiesController extends CoresecureController {
             $supResource = $this->request->getParameterNoException("id_resources");
             $supName = $this->request->getParameterNoException("names");
             $supMandatory = $this->request->getParameterNoException("mandatory");
-            
-            // $count = 0;
+            $supIsInvoicingUnit = $this->request->getParameterNoException("is_invoicing_unit");
 
+            // format into arrays
+            $supIsInvoicingUnit = is_array($supIsInvoicingUnit) ? $supIsInvoicingUnit : [$supIsInvoicingUnit];
+            $supID = is_array($supID) ? $supID : [$supID];
 
+            // TODO: check if this next loops are ok
             $packs = [];
             for ($p = 0; $p < count($supID); $p++) {
                 if ($supName[$p] != "" && $supID[$p]) {
@@ -99,6 +104,7 @@ class BookingquantitiesController extends CoresecureController {
                 }
                 $modelSups->setCalQuantity($id_space,  $supID[$p], $supResource[$p], $supName[$p], $supMandatory[$p]);
             }
+            
 
             /* bug to get last id (could conflict)
             // get the last package id

--- a/Modules/booking/Controller/BookingschedulingController.php
+++ b/Modules/booking/Controller/BookingschedulingController.php
@@ -95,7 +95,7 @@ class BookingschedulingController extends CoresecureController {
         // if no color code was created, then alert user it is required to do so
         if (!$colors) {
             // display alert
-            $_SESSION["message"] = BookingTranslator::MissingColorCode($lang);
+            $_SESSION["flash"] = BookingTranslator::MissingColorCode($lang);
         }
         
         $cc = array(); $ccid = array();

--- a/Modules/booking/Model/BkCalQuantities.php
+++ b/Modules/booking/Model/BkCalQuantities.php
@@ -22,6 +22,7 @@ class BkCalQuantities extends Model {
         `id_resource` int(11) NOT NULL,
         `name` varchar(30) NOT NULL DEFAULT '',
 		`mandatory` int(1) NOT NULL,
+        `is_invoicing_unit` int(1) NOT NULL DEFAULT 0,
 		PRIMARY KEY (`id`)
 		);";
 
@@ -104,10 +105,10 @@ class BkCalQuantities extends Model {
      * @param unknown $name
      * @param unknown $mandatory
      */
-    public function addCalQuantity($id_space, $id_quantity, $id_resource, $name, $mandatory) {
-        $sql = "insert into bk_calquantities(id_quantity, id_resource, name, mandatory, id_space)"
-                . " values(?,?,?,?,?)";
-        $this->runRequest($sql, array($id_quantity, $id_resource, $name, $mandatory, $id_space));
+    public function addCalQuantity($id_space, $id_quantity, $id_resource, $name, $mandatory, $is_invoicing_unit = 0) {
+        $sql = "insert into bk_calquantities(id_space, id_quantity, id_resource, name, mandatory, is_invoicing_unit)"
+                . " values(?,?,?,?,?,?)";
+        $this->runRequest($sql, array($id_space, $id_quantity, $id_resource, $name, $mandatory, $is_invoicing_unit));
     }
 
     /**
@@ -116,12 +117,12 @@ class BkCalQuantities extends Model {
      * @param unknown $name
      * @param unknown $mandatory
      */
-    public function setCalQuantity($id_space, $id_quantity, $id_resource, $name, $mandatory) {
+    public function setCalQuantity($id_space, $id_quantity, $id_resource, $name, $mandatory, $is_invoicing_unit = 0) {
 
         if ($this->isCalQuantityId($id_space, $id_quantity, $id_resource)) {
-            $this->updateCalQuantity($id_space, $id_quantity, $id_resource, $name, $mandatory);
+            $this->updateCalQuantity($id_space, $id_quantity, $id_resource, $name, $mandatory, $is_invoicing_unit);
         } else {
-            $this->addCalQuantity($id_space, $id_quantity, $id_resource, $name, $mandatory);
+            $this->addCalQuantity($id_space, $id_quantity, $id_resource, $name, $mandatory, $is_invoicing_unit);
         }
     }
 
@@ -141,10 +142,11 @@ class BkCalQuantities extends Model {
      * @param unknown $id
      * @param unknown $name
      * @param unknown $mandatory
+     * @param int $is_invoicing_unit
      */
-    public function updateCalQuantity($id_space, $id_quantity, $id_resource, $name, $mandatory) {
-        $sql = "update bk_calquantities set name= ?, mandatory=? where id_quantity=? AND id_resource=? AND deleted=0 AND id_space=?";
-        $this->runRequest($sql, array($name, $mandatory, $id_quantity, $id_resource, $id_space));
+    public function updateCalQuantity($id_space, $id_quantity, $id_resource, $name, $mandatory, $is_invoicing_unit = 0) {
+        $sql = "update bk_calquantities set name= ?, mandatory=?, is_invoicing_unit = ? where id_quantity=? AND id_resource=? AND deleted=0 AND id_space=?";
+        $this->runRequest($sql, array($name, $mandatory, $is_invoicing_unit, $id_quantity, $id_resource, $id_space));
     }
 
     /**
@@ -159,7 +161,7 @@ class BkCalQuantities extends Model {
 
     /**
      * Set the supplementary of a calendar entry
-     * @param unknown $calsupNames
+     * @param array $calsupNames
      * @param unknown $calsupValues
      * @param unknown $reservation_id
      */
@@ -215,7 +217,7 @@ class BkCalQuantities extends Model {
 
     public function removeUnlistedQuantities($id_space, $packageID) {
 
-        $sql = "select id, id_quantity from bk_calquantities AND id_space=?";
+        $sql = "select id, id_quantity from bk_calquantities WHERE id_space=?";
         $req = $this->runRequest($sql);
         $databasePackages = $req->fetchAll();
 

--- a/Modules/booking/Model/BkCalQuantities.php
+++ b/Modules/booking/Model/BkCalQuantities.php
@@ -218,9 +218,8 @@ class BkCalQuantities extends Model {
     public function removeUnlistedQuantities($id_space, $packageID) {
 
         $sql = "select id, id_quantity from bk_calquantities WHERE id_space=?";
-        $req = $this->runRequest($sql);
+        $req = $this->runRequest($sql, array($id_space));
         $databasePackages = $req->fetchAll();
-
         foreach ($databasePackages as $dbPackage) {
             $found = false;
             foreach ($packageID as $pid) {

--- a/Modules/booking/Model/BkColorCode.php
+++ b/Modules/booking/Model/BkColorCode.php
@@ -301,7 +301,7 @@ class BkColorCode extends Model {
      * @param unknown $id
      */
     public function delete($id_space, $id) {
-        $sql = "UPDATE bk_color_codes SET deleted=1,deleted_at=NOW() WHERE id=? AND id_space=?";
+        $sql = "UPDATE bk_color SET deleted=1,deleted_at=NOW() WHERE id=? AND id_space=?";
         $this->runRequest($sql, array($id, $id_space));
     }
 

--- a/Modules/booking/Model/BookingTranslator.php
+++ b/Modules/booking/Model/BookingTranslator.php
@@ -1645,9 +1645,9 @@ class BookingTranslator {
 
     public static function maxInvoicingUnits($lang) {
         if ($lang == "fr") {
-            return "Seulement une quantité peut être utilisée comme unité de facturation. Merci de passer \"Utiliser comme unité de facturation\" à \"non\" pour les autres quantités.";
+            return "Seule une quantité peut être utilisée comme unité de facturation pour une ressource. Merci de passer \"Utiliser comme unité de facturation\" à \"non\" pour les autres quantités concernées.";
         } else {
-            return "Only one quantity can be used as an invoicing unit. Please set \"Use as invoicing unit\" to \"no\" for other quantites.";
+            return "Only one quantity can be used as an invoicing unit for one resource. Please set \"Use as invoicing unit\" to \"no\" for other quantites.";
         }
     }
 }

--- a/Modules/booking/Model/BookingTranslator.php
+++ b/Modules/booking/Model/BookingTranslator.php
@@ -725,6 +725,13 @@ class BookingTranslator {
         return "Is mandatory";
     }
 
+    public static function Is_invoicing_unit($lang) {
+        if ($lang == "fr") {
+            return "Utiliser comme unité de facturation";
+        }
+        return "Use as invoicing unit";
+    }
+
     public static function Supplementaries_saved($lang) {
         if ($lang == "fr") {
             return "Les suppléments ont été sauvegardés";
@@ -1634,5 +1641,13 @@ class BookingTranslator {
             return "Erreur : Aucun domaine et / ou aucune ressource n'a été créé";
         }
         return "Error: No resource and/or area has been created";
+    }
+
+    public static function maxInvoicingUnits($lang) {
+        if ($lang == "fr") {
+            return "Seulement une quantité peut être utilisée comme unité de facturation. Merci de passer \"Utiliser comme unité de facturation\" à \"non\" pour les autres quantités.";
+        } else {
+            return "Only one quantity can be used as an invoicing unit. Please set \"Use as invoicing unit\" to \"no\" for other quantites.";
+        }
     }
 }

--- a/Modules/booking/View/Bookingprices/editscript.php
+++ b/Modules/booking/View/Bookingprices/editscript.php
@@ -1,8 +1,14 @@
 <?php ?>
 
 <script>
+    class ResourceBkPricing {
+        constructor(resourceId, resourceName, belongingPrices) {
+            this.resourceId = resourceId;
+            this.resourceName = resourceName;
+            this.belongingPrices = belongingPrices;
+        }
+    }
     $(document).ready(function () {
-
         $("#hider").hide();
         $("#entriesbuttonclose").click(function () {
             $("#hider").hide();
@@ -14,36 +20,38 @@
                 
                 var strid = this.id;
                 var arrayid = strid.split("_");
-                //alert("add note clicked " + arrayid[1]);
                 showEditEntryForm(<?php echo $id_space ?>, arrayid[1]);
             });
     <?php
 }
 ?>
-
+        /**
+         * Gets bookingPrices from BookingpricesApi then calls displayPopup()
+         * 
+         * @param string id_space
+         * @param string id_resource 
+         * 
+         */
         function showEditEntryForm(id_space, id_service) {
-            $.post(
-                    'bookinggetprices/' + id_space + '/' + id_service,
-                    {},
-                    function (data) {
-                        $('#resource_id').val(data.id_resource);
-                        $('#resource').val(data.resource);
-                        <?php 
-                        foreach($belongings as $belonging){
-                            ?>
-                             $('<?php echo '#bel_' . $belonging['id'] ?>').val(data.<?php echo 'bel_' . $belonging['id'] ?>);               
-                        <?php                    
+            const bkPricing = new ResourceBkPricing();
+            bkPricing.resourceId = id_resource;
+            bkPricing.belongingPrices = [];
+            $.post('bookinggetprices/' + id_space + '/' + id_resource)
+                .done((response) => {
+                    jsonData = response.includes("<br />") ?  jsonData = response.slice(0, response.indexOf("<br />")) : response;
+                    data = JSON.parse(jsonData);
+
+                    // format to be used more easily
+                    Object.entries(data).forEach((entry) => {
+                        const [key, value] = entry;
+                        if (key.slice(0, 4) === "bel_") {
+                            bkPricing.belongingPrices.push({belonging: key, price: value});
+                        } else if (key === "resource") {
+                            bkPricing.resourceName = value;
                         }
-                        ?>
-
-                        $("#hider").fadeIn("slow");
-                        $('#entriespopup_box').fadeIn("slow");
-                    },
-                    'json'
-                    );
-
+                    });
+                    displayPopup(bkPricing);
+            });
         }
-        ;
-
     });
 </script>            

--- a/Modules/booking/View/Bookingprices/editscript.php
+++ b/Modules/booking/View/Bookingprices/editscript.php
@@ -32,10 +32,12 @@
          * @param string id_resource 
          * 
          */
-        function showEditEntryForm(id_space, id_service) {
+        function showEditEntryForm(id_space, id_resource) {
+            console.log("in showEditForm");
             const bkPricing = new ResourceBkPricing();
             bkPricing.resourceId = id_resource;
             bkPricing.belongingPrices = [];
+
             $.post('bookinggetprices/' + id_space + '/' + id_resource)
                 .done((response) => {
                     jsonData = response.includes("<br />") ?  jsonData = response.slice(0, response.indexOf("<br />")) : response;
@@ -53,5 +55,21 @@
                     displayPopup(bkPricing);
             });
         }
+        /**
+         * Displays a popup window #entriespopup_box
+         * to edit resource prices
+         * 
+         * @param ResourceBkPricing bkPricing
+         * 
+         */
+        function displayPopup(bkPricing) {
+            $('#resource_id').val(bkPricing.resourceId);
+            $('#resource').val(bkPricing.resourceName);
+            bkPricing.belongingPrices.forEach( (bkPrice) => {
+                $('#' + bkPrice.belonging).val(bkPrice.price);
+            });
+            $("#hider").fadeIn("slow");
+            $('#entriespopup_box').fadeIn("slow");
+        }
     });
-</script>            
+</script>

--- a/Modules/booking/View/Bookingquantities/indexAction.php
+++ b/Modules/booking/View/Bookingquantities/indexAction.php
@@ -5,30 +5,6 @@
 
 <div class="col-md-12 pm-table">
     
-    <?php 
-    if (isset($_SESSION["message"]) && $_SESSION["message"] != "") {
-        $dismissible = false;
-        if (array_key_exists("dismissible", $_SESSION["message"])) {
-            $dismissible = $_SESSION["message"]["dismissible"];
-        }
-?>
-        <div class="row">
-            <div class="col-xs-12 col-md-10 col-md-offset-1" style="padding-top: 12px;" >
-                <div class="alert <?php echo $_SESSION["message"]["type"] ?>" role="alert">
-                    <?php echo $_SESSION["message"]["content"];
-                        if ($dismissible) {
-                    ?>
-                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                    <?php } ?>
-                </div>
-            </div>
-        </div>
-    <?php }
-    $_SESSION["message"] = "";
-    ?>
-    
     <?php echo $formHtml ?>
     
 </div>

--- a/Modules/booking/View/Bookingquantities/indexAction.php
+++ b/Modules/booking/View/Bookingquantities/indexAction.php
@@ -6,11 +6,23 @@
 <div class="col-md-12 pm-table">
     
     <?php 
-    if (isset($_SESSION["message"]) && $_SESSION["message"] != ""){ 
-        ?>
-        <div class="col-xs-12 col-md-10 col-md-offset-1" style="padding-top: 12px;" >
-            <div class="alert alert-success" role="alert">
-            <p><?php echo $_SESSION["message"] ?></p>
+    if (isset($_SESSION["message"]) && $_SESSION["message"] != "") {
+        $dismissible = false;
+        if (array_key_exists("dismissible", $_SESSION["message"])) {
+            $dismissible = $_SESSION["message"]["dismissible"];
+        }
+?>
+        <div class="row">
+            <div class="col-xs-12 col-md-10 col-md-offset-1" style="padding-top: 12px;" >
+                <div class="alert <?php echo $_SESSION["message"]["type"] ?>" role="alert">
+                    <?php echo $_SESSION["message"]["content"];
+                        if ($dismissible) {
+                    ?>
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    <?php } ?>
+                </div>
             </div>
         </div>
     <?php }

--- a/Modules/clients/Controller/ClientspricingsController.php
+++ b/Modules/clients/Controller/ClientspricingsController.php
@@ -82,7 +82,7 @@ class ClientspricingsController extends CoresecureController {
             $pricing = array("id" => 0, "name" => "");
         }
         else{
-            $pricing = $this->pricingModel->get($is_space, $id);
+            $pricing = $this->pricingModel->get($id_space, $id);
         }
         
         

--- a/Modules/clients/Model/ClPricing.php
+++ b/Modules/clients/Model/ClPricing.php
@@ -17,7 +17,7 @@ class ClPricing extends Model {
     }
 
     public function getAll($id_space) {
-        $sql = "SELECT * FROM cl_pricings WHERE id_space=? AND deleted=?";
+        $sql = "SELECT * FROM cl_pricings WHERE id_space=? AND deleted=0";
         return $this->runRequest($sql, array($id_space))->fetchAll();
     }
 

--- a/Modules/core/Model/CoreInstall.php
+++ b/Modules/core/Model/CoreInstall.php
@@ -115,6 +115,10 @@ class CoreDB extends Model {
         }
         Configuration::getLogger()->debug("[users] add apikey done!");
 
+        Configuration::getLogger()->debug("[booking] add is_invoicing_unit");
+        $bkqte = new BkCalQuantities();
+        $bkqte->addColumn("bk_calquantities", "is_invoicing_unit", "int(1)", 0);
+        Configuration::getLogger()->debug("[booking] add is_invoicing_unit done!");
 
         Configuration::getLogger()->debug("[adminmenu] remove update");
         $cam = new CoreAdminMenu();

--- a/Modules/core/Model/CoreInstall.php
+++ b/Modules/core/Model/CoreInstall.php
@@ -115,11 +115,6 @@ class CoreDB extends Model {
         }
         Configuration::getLogger()->debug("[users] add apikey done!");
 
-        Configuration::getLogger()->debug("[booking] add is_invoicing_unit");
-        $bkqte = new BkCalQuantities();
-        $bkqte->addColumn("bk_calquantities", "is_invoicing_unit", "int(1)", 0);
-        Configuration::getLogger()->debug("[booking] add is_invoicing_unit done!");
-
         Configuration::getLogger()->debug("[adminmenu] remove update");
         $cam = new CoreAdminMenu();
         $cam->removeAdminMenu("Update");
@@ -501,6 +496,10 @@ class CoreDB extends Model {
         }
         Configuration::getLogger()->debug('[space] remove super admin from spaces admins, done!');
 
+        Configuration::getLogger()->debug("[booking] add is_invoicing_unit");
+        $bkqte = new BkCalQuantities();
+        $bkqte->addColumn("bk_calquantities", "is_invoicing_unit", "int(1)", 0);
+        Configuration::getLogger()->debug("[booking] add is_invoicing_unit done!");
     }
 
 

--- a/Modules/invoices/Controller/InvoiceslistController.php
+++ b/Modules/invoices/Controller/InvoiceslistController.php
@@ -180,7 +180,7 @@ class InvoiceslistController extends CoresecureController {
         $form = new Form($this->request, "infoActionForm");
         $form->setTitle(InvoicesTranslator::InvoiceInfo($lang));
         $form->addText("number", InvoicesTranslator::Number($lang), false, $invoice["number"], false);
-        $form->addText("resp", ClientsTranslator::ClientAccount($lang), false, $modelClient->getName($invoice["id_responsible"]), false);
+        $form->addText("resp", ClientsTranslator::ClientAccount($lang), false, $modelClient->getName($id_space, $invoice["id_responsible"]), false);
         $form->addDate("date_generated", InvoicesTranslator::Date_generated($lang), true, CoreTranslator::dateFromEn($invoice["date_generated"], $lang));
         $form->addDate("date_send", InvoicesTranslator::Date_send($lang), true, CoreTranslator::dateFromEn($invoice["date_send"], $lang));
         

--- a/Modules/invoices/Model/InvoiceModel.php
+++ b/Modules/invoices/Model/InvoiceModel.php
@@ -8,6 +8,6 @@ abstract class InvoiceModel extends Model {
     public abstract function hasActivity($id_space, $beginPeriod, $endPeriod, $id_resp);
     public abstract function invoice($id_space, $beginPeriod, $endPeriod, $id_resp, $invoice_id, $lang);
     public abstract function details($id_space, $invoice_id, $lang);
-    public abstract function delete($id_invoice);
+    public abstract function delete($id_space, $id_invoice);
     
 }

--- a/Modules/resources/Model/ResourceInfo.php
+++ b/Modules/resources/Model/ResourceInfo.php
@@ -167,9 +167,9 @@ class ResourceInfo extends Model {
     /**
      * Get the resources IDs and names for a given Area
      * @param unknown $areaId
-     * @return multitype:
+     * @return array
      */
-    public function resourceIDNameForArea($id_space, $areaId) {
+    public function resourceIDNameForArea($id_space, $areaId): array {
         $sql = "SELECT id, name from re_info where id_area=? AND id_space=? AND deleted=0 ORDER BY display_order";
         $data = $this->runRequest($sql, array($areaId, $id_space));
         return $data->fetchAll();

--- a/Modules/services/Api/ServicespricesApi.php
+++ b/Modules/services/Api/ServicespricesApi.php
@@ -34,9 +34,9 @@ class ServicespricesApi extends CoresecureController {
         $data = array();
         
         $data['id_service'] = $id_service;
-        $data['service'] = $modelService->getItemName($id_service);
+        $data['service'] = $modelService->getItemName($id_space, $id_service);
         for($i = 0 ; $i < count($belongings) ; $i++){
-            $price = $modelPrices->getPrice($id_service, $belongings[$i]["id"]);
+            $price = $modelPrices->getPrice($id_space, $id_service, $belongings[$i]["id"]);
             $data['bel_'.$belongings[$i]['id']] = floatval($price); 
         }
         

--- a/Modules/services/View/Servicesprices/editscript.php
+++ b/Modules/services/View/Servicesprices/editscript.php
@@ -1,6 +1,15 @@
 <?php ?>
 
 <script>
+
+class ServiceBkPricing {
+        constructor(serviceId, serviceName, belongingPrices) {
+            this.serviceId = serviceId;
+            this.serviceName = serviceName;
+            this.belongingPrices = belongingPrices;
+        }
+    }
+
     $(document).ready(function () {
 
         $("#hider").hide();
@@ -14,36 +23,56 @@
                 
                 var strid = this.id;
                 var arrayid = strid.split("_");
-                //alert("edit note clicked " + arrayid[1]);
                 showEditEntryForm(<?php echo $id_space ?>, arrayid[1]);
             });
     <?php
 }
 ?>
-
+        /**
+         * Gets bookingPrices from ServicespricesApi then calls displayPopup()
+         * 
+         * @param string id_space
+         * @param string id_service 
+         * 
+         */
         function showEditEntryForm(id_space, id_service) {
-            $.post(
-                    'servicesgetprices/' + id_space + '/' + id_service,
-                    {},
-                    function (data) {
-                        $('#service_id').val(data.id_service);
-                        $('#service').val(data.service);
-                        <?php 
-                        foreach($belongings as $belonging){
-                            ?>
-                             $('<?php echo '#bel_' . $belonging['id'] ?>').val(data.<?php echo 'bel_' . $belonging['id'] ?>);               
-                        <?php                    
+            const bkPricing = new ServiceBkPricing();
+            bkPricing.serviceId = id_service;
+            bkPricing.belongingPrices = [];
+            $.post('servicesgetprices/' + id_space + '/' + id_service)
+                .done((response) => {
+                    alert(response);
+                    jsonData = response.includes("<br />") ?  jsonData = response.slice(0, response.indexOf("<br />")) : response;
+                    data = JSON.parse(jsonData);
+
+                    // format to be used more easily
+                    Object.entries(data).forEach((entry) => {
+                        const [key, value] = entry;
+                        if (key.slice(0, 4) === "bel_") {
+                            bkPricing.belongingPrices.push({belonging: key, price: value});
+                        } else if (key === "service") {
+                            bkPricing.serviceName = value;
                         }
-                        ?>
-
-                        $("#hider").fadeIn("slow");
-                        $('#entriespopup_box').fadeIn("slow");
-                    },
-                    'json'
-                    );
-
+                    });
+                    displayPopup(bkPricing);
+            });
         }
-        ;
+        /**
+         * Displays a popup window #entriespopup_box
+         * to edit service prices
+         * 
+         * @param ServiceBkPricing bkPricing
+         * 
+         */
+        function displayPopup(bkPricing) {
+            $('#service_id').val(bkPricing.serviceId);
+            $('#service').val(bkPricing.serviceName);
+            bkPricing.belongingPrices.forEach( (bkPrice) => {
+                $('#' + bkPrice.belonging).val(bkPrice.price);
+            });
+            $("#hider").fadeIn("slow");
+            $('#entriespopup_box').fadeIn("slow");
+        }
 
     });
 </script>            


### PR DESCRIPTION
Replaces MR #207 
Closes #109 

![invoiceByQuantity](https://user-images.githubusercontent.com/48911130/135582456-15783e12-3597-4d3d-9d5a-8512a97b22f5.png)

enhancement : booking invoices can be generated taking quantities into account
By default, even if quantity field is not displayed in booking edition form, quantity = 1
Shouldn't have any impact on cases when not using quantity parameter

How it works:
For each reservation, calculate its price.

**2 general cases:**
- booked resource price depends on duration, then it costs Unit price * reservation duration (in hours)
- booked resource price depends on a quantity of elements, then it costs Unit price * nb elements (quantity)

Unit prices can depend on the period booked (day, night, week-end)
     
**Specific case:**
- if a reservation depending on quantity of elements is stradding 2 types of period (i.e. night and day),
then a ratio is applied.
example:
for a reservation covering 2 night hours and 6 day hours => nightRatio = 0.25 and dayRatio = 0.75
if nightPrice = 20€/element and dayPrice = 10€/element,
totalPrice = nbElements * (nightPrice * nightRatio) + nbElements * (dayPrice * dayRatio)