### PR TITLE
fix resources visa listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.1
 
+* fix resources visa listing
 * #234 fix defaults in db schema
 * #230 generate apikey on ldap login
 * #233 fix schema of core_j_spaces_user

--- a/Modules/resources/Model/ReVisa.php
+++ b/Modules/resources/Model/ReVisa.php
@@ -115,7 +115,7 @@ class ReVisa extends Model {
     
     public function getVisasBySpace($id_space, $sortentry = 'id') {
     
-        $sql = "SELECT * FROM re_visas WHERE deleted=0 AND id_resource_category IN (SELECT id FROM re_category WHERE id_space=? AND delelted=0) order by " . $sortentry . " ASC;";
+        $sql = "SELECT * FROM re_visas WHERE deleted=0 AND id_resource_category IN (SELECT id FROM re_category WHERE id_space=? AND deleted=0) order by " . $sortentry . " ASC;";
         $user = $this->runRequest($sql, array($id_space));
         return $user->fetchAll();
     }


### PR DESCRIPTION
Found while testing pfm2 for next release:
 
A typo in sql request in function ReVisa::getVisasBySpace() avoids resources visas to display at {host}/resourcesvisa/{id_space}.
This MR fixes this.

To be merged or 2.1 or 2.2, it's up to you @osallou.