### PR TITLE
disable resource input in reservation form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 only, not configurable via UI anymore and existing values not taken into account.
 See ldap.ini.example if needed or doc for env variables.
 
+* [booking] avoid any resource selection in resources input
 * [booking] Fix reservation form unexpected submissions
 * [booking] fix bk_scheduling fetching from booking view
 * [self_registration] add structures names to listed spaces

--- a/Modules/booking/Controller/BookingdefaultController.php
+++ b/Modules/booking/Controller/BookingdefaultController.php
@@ -128,7 +128,20 @@ class BookingdefaultController extends BookingabstractController {
 
     public function editreservationqueryAction($id_space) {
         $this->checkAuthorizationMenuSpace("booking", $id_space, $_SESSION["id_user"]);
-        //FIXME: editng an existing reservation does not seem to work
+        $lang = $this->getLanguage();
+        $modelResource = new ResourceInfo();
+        $id_resourcecategory = $modelResource->get($id_space, $this->request->getParameter("id_resource"));
+        $modelAuth = new BkAuthorization();
+        $isUserAuthorizedToBook = $modelAuth->hasAuthorization($id_space, $id_resourcecategory, $_SESSION["id_user"]);
+        $modelSpace = new CoreSpace();
+        $role = $modelSpace->getUserSpaceRole($id_space, $_SESSION["id_user"]);
+        if (!$isUserAuthorizedToBook && $role < CoreSpace::$MANAGER) {
+            $_SESSION['flash'] = BookingTranslator::resourceBookingUnauthorized($lang);
+            $_SESSION['flashClass'] = "warning";
+            $this->redirect("booking/".$id_space);
+            return;
+        }
+
         $responsible_id = $this->request->getParameterNoException("responsible_id");
 
         $id = $this->request->getParameter("id");
@@ -141,12 +154,9 @@ class BookingdefaultController extends BookingabstractController {
         $full_description = $this->request->getParameterNoException("full_description");
         $all_day_long = intval($this->request->getParameterNoException("all_day_long"));
 
-        $lang = $this->getLanguage();
         $dateResaStart = CoreTranslator::dateToEn($this->request->getParameter("resa_start"), $lang);
         $dateResaStartArray = explode("-", $dateResaStart);
 
-
-        $modelResource = new ResourceInfo();
         $ri = $modelResource->get($id_space ,$id_resource);
         if(!$ri){
             Configuration::getLogger()->error('Unauthorized access to resource', ['resource' => $id_resource]);
@@ -558,7 +568,7 @@ class BookingdefaultController extends BookingabstractController {
             $form->addSelect("id_resource", ResourcesTranslator::resource($lang), $resources["names"], $resources["ids"], $id_resource);
             $form->addSelect("recipient_id", CoreTranslator::User($lang), $users["names"], $users["ids"], $resaInfo["recipient_id"]);
         } else {
-            $form->addText('id_resource', ResourcesTranslator::resource($lang), true, $resourceName, 'disabled');
+            $form->addText('resource_name', ResourcesTranslator::resource($lang), true, $resourceName, 'disabled');
             $form->addHidden("id_resource", $id_resource);
             $form->addHidden("recipient_id", $resaInfo["recipient_id"]);
         }

--- a/Modules/booking/Controller/BookingdefaultController.php
+++ b/Modules/booking/Controller/BookingdefaultController.php
@@ -553,10 +553,13 @@ class BookingdefaultController extends BookingabstractController {
         $form->setValisationUrl("bookingeditreservationquery/" . $id_space);
         $form->setTitle($formTitle);
 
-        $form->addSelect("id_resource", ResourcesTranslator::resource($lang), $resources["names"], $resources["ids"], $id_resource);
+        $resourceName = $modelResource->get($id_space, $id_resource)['name'];
         if ($this->canBookForOthers($id_space, $_SESSION["id_user"])) {
+            $form->addSelect("id_resource", ResourcesTranslator::resource($lang), $resources["names"], $resources["ids"], $id_resource);
             $form->addSelect("recipient_id", CoreTranslator::User($lang), $users["names"], $users["ids"], $resaInfo["recipient_id"]);
         } else {
+            $form->addText('id_resource', ResourcesTranslator::resource($lang), true, $resourceName, 'disabled');
+            $form->addHidden("id_resource", $id_resource);
             $form->addHidden("recipient_id", $resaInfo["recipient_id"]);
         }
         // responsible

--- a/Modules/booking/Model/BookingTranslator.php
+++ b/Modules/booking/Model/BookingTranslator.php
@@ -1636,6 +1636,13 @@ class BookingTranslator {
         return "Booking access";
     }
 
+    public static function resourceBookingUnauthorized($lang) {
+        if ($lang == "fr") {
+            return "vous n'êtes pas autorisé à créer/modifier de réservations pour cette ressource";
+        }
+        return "You have no authorization to create nor edit reservations for this resource";
+    }
+
     public static function MissingColorCode($lang) {
         if ($lang == "fr") {
             return "Vous devez créer au moins un code couleur afin de pouvoir éditer les horaires";


### PR DESCRIPTION
For a user, *resources* input will show the resource they chose in calendar view. It is no longer possible to change it.
For those who can "book for others", like admins, resources input is still a select giving access to any of the space resources.