### PR TITLE
Fix corespaceuseraccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [invoice][booking] manage case where total hours = 0
 * [core] add login button on welcome page
 * [booking] for multi slot bookings, do not display next slot content
+* [core] fix corespaceuseraccess when clients or booking modules are in inactive status
 
 ## 2.5.4
 

--- a/Framework/FormElements.php
+++ b/Framework/FormElements.php
@@ -153,7 +153,6 @@ abstract class FormElement {
         if ($this->isMandatory()) {
             $reqTxt = ' *';
         }
-        Configuration::getLogger()->error('???????,',['l' => $this->label]);
         return <<<HTML
         <label class="{$this->getLabelSize()} col-form-label">{$this->label}{$reqTxt}</label>
         HTML;

--- a/Modules/core/Controller/CorespaceaccessController.php
+++ b/Modules/core/Controller/CorespaceaccessController.php
@@ -464,7 +464,7 @@ class CorespaceaccessController extends CoresecureController {
     }
 
     public function generateSpaceAccessForm($id_space, $id_user, $todo=false) {
-        $this->checkAuthorizationMenuSpace("clients", $id_space, $_SESSION["id_user"]);
+        // $this->checkAuthorizationMenuSpace("clients", $id_space, $_SESSION["id_user"]);
         $lang = $this->getLanguage();
         $modelSpace = new CoreSpace();
 
@@ -493,7 +493,7 @@ class CorespaceaccessController extends CoresecureController {
     }
 
     public function validateSpaceAccessForm($id_space, $id_user, $form) {
-        $this->checkAuthorizationMenuSpace("clients", $id_space, $_SESSION["id_user"]);
+        // $this->checkAuthorizationMenuSpace("clients", $id_space, $_SESSION["id_user"]);
         $lang = $this->getLanguage();
         $modelUserSpace = new CoreSpaceUser();
 

--- a/Modules/core/Controller/CorespaceuserController.php
+++ b/Modules/core/Controller/CorespaceuserController.php
@@ -65,9 +65,9 @@ class CorespaceuserController extends CorespaceaccessController {
         $modelSpace = new CoreSpace();
         $moduleRole = CoreSpace::$INACTIF;
         if (in_array('clients', $modules)) {
-            $moduleRole = $modelSpace->getSpaceMenusRole('clients', $id_space);
+            $moduleRole = $modelSpace->getSpaceMenusRole($id_space, 'clients');
         }
-        if ($moduleRole > CoreSpace::$INACTIF) {
+        if ($moduleRole) {
             $clientsUsersCTRL = new ClientsuseraccountsController($this->request);
             $clientsUserForm = $clientsUsersCTRL->generateClientsUserForm($id_space, $id_user, $todo);
             $clientsUserFormHtml = $clientsUserForm->getHtml($lang);
@@ -88,9 +88,9 @@ class CorespaceuserController extends CorespaceaccessController {
         $bkHistoryTableHtml = "";
         $moduleRole = CoreSpace::$INACTIF;
         if (in_array('booking', $modules)) {
-            $moduleRole = $modelSpace->getSpaceMenusRole('clients', $id_space);
+            $moduleRole = $modelSpace->getSpaceMenusRole($id_space, 'booking');
         }
-        if ($moduleRole > CoreSpace::$INACTIF) {
+        if ($moduleRole) {
             $bookingAuthCTRL = new BookingauthorisationsController($this->request);
             $bkAuthAddForm = $bookingAuthCTRL->generateBkAuthAddForm($id_space, $id_user, "corespaceuseredit", $lang, $todo);
             $bkAuthAddFormHtml = $bkAuthAddForm->getHtml($lang);

--- a/Modules/core/Controller/CorespaceuserController.php
+++ b/Modules/core/Controller/CorespaceuserController.php
@@ -43,7 +43,9 @@ class CorespaceuserController extends CorespaceaccessController {
             ? true : false;
         $modelOptions = new CoreSpaceAccessOptions();
         $options = array_reverse($modelOptions->getAll($id_space));
-        $modules = array_map(function($option) { return $option['module'];}, $options);
+        $modules = array_map(function($option) {
+            return $option['module'];
+        }, $options);
 
         $spaceAccessForm = $this->generateSpaceAccessForm($id_space, $id_user, $todo);
         $spaceAccessFormHtml = $spaceAccessForm->getHtml($lang);
@@ -59,7 +61,13 @@ class CorespaceuserController extends CorespaceaccessController {
 
         $clientsUserFormHtml = "";
         $clientsUsertableHtml = "";
+
+        $modelSpace = new CoreSpace();
+        $moduleRole = CoreSpace::$INACTIF;
         if (in_array('clients', $modules)) {
+            $moduleRole = $modelSpace->getSpaceMenusRole('clients', $id_space);
+        }
+        if ($moduleRole > CoreSpace::$INACTIF) {
             $clientsUsersCTRL = new ClientsuseraccountsController($this->request);
             $clientsUserForm = $clientsUsersCTRL->generateClientsUserForm($id_space, $id_user, $todo);
             $clientsUserFormHtml = $clientsUserForm->getHtml($lang);
@@ -78,7 +86,11 @@ class CorespaceuserController extends CorespaceaccessController {
         $bkAuthAddFormHtml = "";
         $bkAuthTableHtml = "";
         $bkHistoryTableHtml = "";
+        $moduleRole = CoreSpace::$INACTIF;
         if (in_array('booking', $modules)) {
+            $moduleRole = $modelSpace->getSpaceMenusRole('clients', $id_space);
+        }
+        if ($moduleRole > CoreSpace::$INACTIF) {
             $bookingAuthCTRL = new BookingauthorisationsController($this->request);
             $bkAuthAddForm = $bookingAuthCTRL->generateBkAuthAddForm($id_space, $id_user, "corespaceuseredit", $lang, $todo);
             $bkAuthAddFormHtml = $bkAuthAddForm->getHtml($lang);


### PR DESCRIPTION
if clients or booking are in inactive state, calls in editactions to client/bookings are made, but user is not able to access it and throw exception (authorization), even space admin.

Also, corespaceacccess generateSpaceAccessForm and validateSpaceAccessForm required access to clients module, though there is no reason for that (edit user info, not client related)