### PR TITLE
add calendar default view option in booking config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.8.0
 
+### Features / enhancements
+
+* [booking] add calendar default view option in booking config
+
 ### Fixes
 
 * [core] fix invalid check on core pending accounts

--- a/Modules/booking/Controller/BookingController.php
+++ b/Modules/booking/Controller/BookingController.php
@@ -147,14 +147,14 @@ class BookingController extends BookingabstractController {
             "view" => $this->request->getParameterNoException('view', default: 'simple')
         ];
 
-        
+
         $bkUserDefaultView = $userSettingsModel->getUserSetting($_SESSION["id_user"], "calendarDefaultView");        
         if (isset($_SESSION['lastbookview'])) {
             $lastView = $_SESSION['lastbookview'];
             $this->redirect($lastView . "/" . $id_space, $qc);
         } else if ($bkUserDefaultView == "") {
             $modelCoreConfig = new CoreConfig();
-            $bkSpaceDefaultView = $modelCoreConfig->getParamSpace("BkSetDefaultView", $id_space, 0);
+            $bkSpaceDefaultView = $modelCoreConfig->getParamSpace("BkSetDefaultView", $id_space, "bookingweekarea");
             $this->redirect($bkSpaceDefaultView . "/" . $id_space, $qc);
         } else {
             $this->redirect($bkUserDefaultView . "/" . $id_space, $qc);

--- a/Modules/booking/Controller/BookingController.php
+++ b/Modules/booking/Controller/BookingController.php
@@ -147,15 +147,17 @@ class BookingController extends BookingabstractController {
             "view" => $this->request->getParameterNoException('view', default: 'simple')
         ];
 
-
-        $calendarDefaultView = $userSettingsModel->getUserSetting($_SESSION["id_user"], "calendarDefaultView");
+        
+        $bkUserDefaultView = $userSettingsModel->getUserSetting($_SESSION["id_user"], "calendarDefaultView");        
         if (isset($_SESSION['lastbookview'])) {
             $lastView = $_SESSION['lastbookview'];
             $this->redirect($lastView . "/" . $id_space, $qc);
-        } else if ($calendarDefaultView == "") {
-            $this->redirect("bookingdayarea/" . $id_space, $qc);
+        } else if ($bkUserDefaultView == "") {
+            $modelCoreConfig = new CoreConfig();
+            $bkSpaceDefaultView = $modelCoreConfig->getParamSpace("BkSetDefaultView", $id_space, 0);
+            $this->redirect($bkSpaceDefaultView . "/" . $id_space, $qc);
         } else {
-            $this->redirect($calendarDefaultView . "/" . $id_space, $qc);
+            $this->redirect($bkUserDefaultView . "/" . $id_space, $qc);
         }
     }
 

--- a/Modules/booking/Controller/BookingconfigController.php
+++ b/Modules/booking/Controller/BookingconfigController.php
@@ -99,6 +99,14 @@ class BookingconfigController extends CoresecureController {
         
             return $this->redirect("bookingconfig/".$id_space);
         }
+
+        $formbookingSetDefaultView = $this->bookingSetDefaultView($id_space, $lang);
+        if ($formbookingSetDefaultView->check()){
+            $modelConfig = new CoreConfig();
+            $modelConfig->setParam("BkSetDefaultView", $this->request->getParameter("BkSetDefaultView"), $id_space);
+        
+            return $this->redirect("bookingconfig/".$id_space);
+        }
         
         /*
         $formBookingCanUserEditStartedResa = $this->bookingCanUserEditStartedResa($id_space, $lang);
@@ -149,6 +157,7 @@ class BookingconfigController extends CoresecureController {
             $formSettingsMenusactivation->getHtml($lang), 
             $formSettingsMenuName->getHtml($lang),
             $formbookingUseRecurentBooking->getHtml($lang),
+            $formbookingSetDefaultView->getHtml($lang),
             //$formBookingCanUserEditStartedResa->getHtml($lang),
             //$bookingRestrictionForm->getHtml($lang),
             $formBookingOption->getHtml($lang), 
@@ -198,6 +207,35 @@ class BookingconfigController extends CoresecureController {
         $form->addSeparator(BookingTranslator::Use_recurent_booking($lang));
         
         $form->addSelect("BkUseRecurentBooking", "", array(CoreTranslator::yes($lang), CoreTranslator::no($lang)), array(1,0), $BkUseRecurentBooking);
+        
+        $form->setValidationButton(CoreTranslator::Save($lang), "bookingconfig/".$id_space);
+
+        return $form;
+    }
+
+    protected function bookingSetDefaultView($id_space, $lang){
+        $modelCoreConfig = new CoreConfig();
+        $BkSetDefaultView = $modelCoreConfig->getParamSpace("BkSetDefaultView", $id_space, 0);
+        
+        $form = new Form($this->request, "BkSetdefaultViewForm");
+        $form->addSeparator(BookingTranslator::Set_default_booking_view($lang));
+
+        $optionsNames = array(
+            BookingTranslator::Day($lang),
+            BookingTranslator::Day_Area($lang),
+            BookingTranslator::Week($lang),
+            BookingTranslator::Week_Area($lang),
+            BookingTranslator::Month($lang)
+        );
+        $optionsValues = array(
+            "bookingday",
+            "bookingdayarea",
+            "bookingweek",
+            "bookingweekarea",
+            "bookingmonth"
+        );
+        
+        $form->addSelect("BkSetDefaultView", "", $optionsNames, $optionsValues, $BkSetDefaultView);
         
         $form->setValidationButton(CoreTranslator::Save($lang), "bookingconfig/".$id_space);
 

--- a/Modules/booking/Controller/BookingconfigController.php
+++ b/Modules/booking/Controller/BookingconfigController.php
@@ -215,7 +215,7 @@ class BookingconfigController extends CoresecureController {
 
     protected function bookingSetDefaultView($id_space, $lang){
         $modelCoreConfig = new CoreConfig();
-        $BkSetDefaultView = $modelCoreConfig->getParamSpace("BkSetDefaultView", $id_space, 0);
+        $BkSetDefaultView = $modelCoreConfig->getParamSpace("BkSetDefaultView", $id_space, "bookingweekarea");
         
         $form = new Form($this->request, "BkSetdefaultViewForm");
         $form->addSeparator(BookingTranslator::Set_default_booking_view($lang));

--- a/Modules/booking/Model/BookingTranslator.php
+++ b/Modules/booking/Model/BookingTranslator.php
@@ -1440,6 +1440,13 @@ class BookingTranslator {
         return "Use recurent booking";
     }
 
+    public static function Set_default_booking_view($lang) {
+        if ($lang == "fr") {
+            return "Utiliser une vue par défaut";
+        }
+        return "Use a default view";
+    }
+
     public static function Single($lang) {
         if ($lang == "fr") {
             return "Simple";


### PR DESCRIPTION
closes #686 
Allow space admins to set a default booking view for all users.
Parameters priority order:
- user last view used (session)
- default view selected by user (core_users_settings)
- default view set in booking config (core_config)
