### PR TITLE
avoid displaying news popup if no news

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [services/clients] prevent pricing removal if used by a client
 * [invoice] manage invoicing/display in case of deleted service
 * [services] fix orders edition form
+* [com] avoid displaying news popup if no news
 
 ## 2.7.1
 

--- a/Modules/com/View/Comhome/comhomeScript.php
+++ b/Modules/com/View/Comhome/comhomeScript.php
@@ -54,8 +54,11 @@ let newsView = Vue.createApp({
                             });
                         });
                     }
+                    return data;
                 }).
-                then(this.displayPopup());
+                then(data => {
+                    if (data.news.length > 0) {this.displayPopup();}
+                });
         },
         displayPopup() {
             let myModal = new bootstrap.Modal(document.getElementById('compopup_box'))


### PR DESCRIPTION
This PR avoid the news popup window to display if there are no news to show.